### PR TITLE
Restore exclusion of gaming PC from ExporterDown alert

### DIFF
--- a/prometheus/config/rules.yml
+++ b/prometheus/config/rules.yml
@@ -15,7 +15,7 @@ groups:
     expr: probe_success == 0
     for: 20m
   - alert: ExporterDown
-    expr: up{job!="node resources", app!="resticprofile"} == 0
+    expr: up{job!="node resources", app!="resticprofile", job!="hwinfo gaming pc"} == 0
     for: 15m
   - alert: CO2_PPM_Too_High
     expr: awair_sensor_co2 > 1000


### PR DESCRIPTION
Exclude job="hwinfo gaming pc" from ExporterDown alert rule. This host goes offline regularly and should not trigger alerts. Restores previous behavior before June 2025.