### PR TITLE
Add pre-commit cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,14 @@ jobs:
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Cache pre-commit
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-precommit-
+
     - name: Setup development environment
       run: nix develop --command echo "Development environment ready"
 


### PR DESCRIPTION
This pull request adds a step to cache the pre-commit environments in the GitHub Actions workflow. This improves workflow speed by reusing pre-commit hooks between runs. Nix store caching is not included, as it is already handled elsewhere.