### PR TITLE
Run CI after automated PR update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Also runs when the render workflow completes
+  workflow_run:
+    workflows: [Render Helm Charts on PR]
+    types: [completed]
 
 jobs:
   lint:

--- a/.github/workflows/render-helm-on-pr.yaml
+++ b/.github/workflows/render-helm-on-pr.yaml
@@ -62,7 +62,7 @@ jobs:
           # Extract the PR branch name
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
           echo "Pushing to branch: $BRANCH_NAME"
-          git push origin HEAD:refs/heads/$BRANCH_NAME
+          git push origin HEAD:refs/heads/"$BRANCH_NAME"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update ci.yaml to run CI both on normal PR events and after the 'Render Helm Charts on PR' workflow completes. This ensures CI validation runs even when the render workflow pushes changes using GITHUB_TOKEN.