### PR TITLE
Remove security context from resticprofile jobs, fix image tag

### DIFF
--- a/resticprofile/cronjob-b2-forget.yaml
+++ b/resticprofile/cronjob-b2-forget.yaml
@@ -27,17 +27,8 @@ spec:
             volumeMounts:
             - mountPath: /tmp
               name: scratch
-          - name: fix-cache-permissions
-            image: alpine
-            command: [sh, -c, chown -R 10007:10007 /cache]
-            volumeMounts:
-            - mountPath: /cache
-              name: cache
           containers:
           - name: resticprofile
-            securityContext:
-              runAsUser: 10007
-              runAsGroup: 10007
             command:
             - resticprofile
             - -c

--- a/resticprofile/cronjob-copy-main.yaml
+++ b/resticprofile/cronjob-copy-main.yaml
@@ -29,9 +29,6 @@ spec:
               name: scratch
           containers:
           - name: resticprofile
-            securityContext:
-              runAsUser: 10007
-              runAsGroup: 10007
             command:
             - resticprofile
             - -c

--- a/resticprofile/cronjob-migrate-azure-to-b2.yaml
+++ b/resticprofile/cronjob-migrate-azure-to-b2.yaml
@@ -28,17 +28,8 @@ spec:
             volumeMounts:
             - mountPath: /tmp
               name: scratch
-          - name: fix-cache-permissions
-            image: alpine
-            command: [sh, -c, chown -R 10007:10007 /cache]
-            volumeMounts:
-            - mountPath: /cache
-              name: cache
           containers:
           - name: resticprofile
-            securityContext:
-              runAsUser: 10007
-              runAsGroup: 10007
             command:
             - resticprofile
             - -c

--- a/resticprofile/kustomization.yaml
+++ b/resticprofile/kustomization.yaml
@@ -25,7 +25,7 @@ images:
 - name: alpine
   newTag: '3.22'
 - name: creativeprojects/resticprofile
-  newTag: v0.31.0
+  newTag: 0.31.0
 
 labels:
 - includeSelectors: true


### PR DESCRIPTION
Removes runAsUser and runAsGroup security contexts from resticprofile cronjobs to allow them to run as root. Also removes the fix-cache-permissions init containers that were setting ownership for user 10007.

Additionally, fixes the image tag formatting for creativeprojects/resticprofile in kustomization.yaml.