### PR TITLE
Add configmap resource to Home Assistant kustomization

### DIFF
--- a/hass/kustomization.yaml
+++ b/hass/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
 - deploy.yaml
+- configmap.yaml
 - externalsecret.yaml
 - ingress.yaml
 - mysql-deploy.yaml


### PR DESCRIPTION
This PR adds a configmap resource to the Home Assistant kustomization configuration.