### PR TITLE
Exclude resticprofile jobs from ExporterDown alert

### DIFF
--- a/prometheus/config/rules.yml
+++ b/prometheus/config/rules.yml
@@ -15,7 +15,7 @@ groups:
     expr: probe_success == 0
     for: 20m
   - alert: ExporterDown
-    expr: up{job!="node resources", app!="resticprofile", job!="hwinfo gaming pc"}
+    expr: up{job!="node resources", job!="hwinfo gaming pc", resticprofile!~".+"}
       == 0
     for: 15m
   - alert: CO2_PPM_Too_High


### PR DESCRIPTION
Resticprofile jobs are transient and should not trigger exporter down notifications.

This updates the alert rule to exclude any metrics with a resticprofile label, ensuring only persistent exporters are monitored for downtime.
