### PR TITLE
Add Chart.yaml and update render-helm.sh for external-secrets

### DIFF
--- a/external-secrets/Chart.yaml
+++ b/external-secrets/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: external-secrets-meta
+version: 0.1.0
+dependencies:
+- name: external-secrets
+  version: 0.9.13
+  repository: https://charts.external-secrets.io

--- a/external-secrets/render-helm.sh
+++ b/external-secrets/render-helm.sh
@@ -5,14 +5,16 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp helm
-helm template external-secrets external-secrets \
-	--version 0.9.13 \
-	--repo https://charts.external-secrets.io \
-	--namespace external-secrets \
-	--values values.yaml \
-	--output-dir tmp
+
+# Render external-secrets chart
+helm_template external-secrets external-secrets \
+  --values values.yaml \
+  --namespace external-secrets \
+  --output-dir tmp
 
 mv tmp/*/* helm
 rmdir tmp/*


### PR DESCRIPTION
Switch external-secrets to use Chart.yaml for version management and update render-helm.sh to match original behavior. No functional changes to rendered output.
