### PR TITLE
Add homepage annotations to n8n ingress via strategic merge patch

### DIFF
--- a/n8n/kustomization.yaml
+++ b/n8n/kustomization.yaml
@@ -30,3 +30,19 @@ resources:
 - helm/valkey/templates/primary/application.yaml
 - helm/valkey/templates/primary/service.yaml
 - helm/valkey/templates/primary/serviceaccount.yaml
+
+patches:
+- target:
+    kind: Ingress
+    name: n8n
+  patch: |-
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: n8n
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: "n8n"
+        gethomepage.dev/description: "Workflow Automation"
+        gethomepage.dev/group: "Miscellaneous"
+        gethomepage.dev/icon: "n8n.png"


### PR DESCRIPTION
Uses an inline strategic merge patch in kustomization.yaml to add gethomepage.dev annotations for automatic discovery in Homepage dashboard.
