### PR TITLE
Add Chart.yaml for metallb project

### DIFF
--- a/metallb/Chart.yaml
+++ b/metallb/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: metallb-meta
+version: 0.1.0
+dependencies:
+- name: metallb
+  version: 0.13.9
+  repository: https://metallb.github.io/metallb

--- a/metallb/helm/templates/speaker.yaml
+++ b/metallb/helm/templates/speaker.yaml
@@ -98,7 +98,7 @@ spec:
             add:
             - NET_RAW
         volumeMounts:
-          - name: memberlist
+          - name: memberlist 
             mountPath: /etc/ml_secret_key
       nodeSelector:
         "kubernetes.io/os": linux

--- a/metallb/render-helm.sh
+++ b/metallb/render-helm.sh
@@ -5,22 +5,11 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
-REPO=https://metallb.github.io/metallb
-NAME=metallb
-VERSION=0.13.9
-
-if [ ! -f values.yaml ]; then
-	touch values.yaml
-fi
+source "$BASEDIR/../scripts/chart-version.sh"
 
 rm -rf helm tmp
 mkdir tmp helm
-helm template "$NAME" "$NAME" \
-	--repo "$REPO" \
-	--include-crds \
-	--version "$VERSION" \
-	--values values.yaml \
-	--output-dir tmp
+helm_template metallb metallb --namespace metallb-system --include-crds --values values.yaml --output-dir tmp
 
 mv tmp/*/* helm
 rmdir tmp/*


### PR DESCRIPTION
Convert metallb to use Helm dependency management with chart-version.sh helper. This makes version management consistent with other projects in the repository.
