### PR TITLE
Move awair-exporter to default namespace and remove namePrefix

### DIFF
--- a/awair-exporter/deploy.yaml
+++ b/awair-exporter/deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: exporter
+  name: awair-exporter
   annotations:
     reloader.stakater.com/auto: 'true'
 spec:
@@ -24,6 +24,6 @@ spec:
         imagePullPolicy: Always
         envFrom:
         - secretRef:
-            name: exporter
+            name: awair-exporter
         ports:
         - containerPort: 8000

--- a/awair-exporter/externalsecret.yaml
+++ b/awair-exporter/externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
     kind: ClusterSecretStore
   refreshInterval: 1h
   target:
-    name: exporter
+    name: awair-exporter
   dataFrom:
   - extract:
       key: awair-exporter

--- a/awair-exporter/kustomization.yaml
+++ b/awair-exporter/kustomization.yaml
@@ -1,8 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kube-system
-namePrefix: awair-
+namespace: default
 
 resources:
 - deploy.yaml

--- a/awair-exporter/service.yaml
+++ b/awair-exporter/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: exporter
+  name: awair-exporter
 spec:
   selector:
     app.kubernetes.io/name: awair-exporter


### PR DESCRIPTION
Move awair-exporter from kube-system to default namespace and remove namePrefix from kustomization.yaml to follow project conventions. Update resource names to be more descriptive and consistent with other components.