### PR TITLE
Update ingress class annotations to modern format

### DIFF
--- a/alertmanager/ingress.yaml
+++ b/alertmanager/ingress.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     k8s-app: alertmanager
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Alertmanager
     gethomepage.dev/group: Monitoring
     gethomepage.dev/icon: alertmanager.png
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - alertmanager.k.oneill.net

--- a/autobrr/ingress.yaml
+++ b/autobrr/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: autobrr
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: autobrr
@@ -29,3 +28,4 @@ spec:
             name: autobrr
             port:
               number: 7474
+  ingressClassName: nginx

--- a/bazarr/ingress.yaml
+++ b/bazarr/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: bazarr
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Bazarr
@@ -29,3 +28,4 @@ spec:
             name: bazarr
             port:
               number: 6767
+  ingressClassName: nginx

--- a/channels/ingress.yaml
+++ b/channels/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: channels
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Channels
@@ -27,3 +26,4 @@ spec:
             name: channels
             port:
               number: 8089
+  ingressClassName: nginx

--- a/cross-seed/ingress.yaml
+++ b/cross-seed/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: cross-seed
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
@@ -24,3 +23,4 @@ spec:
             name: cross-seed
             port:
               number: 2468
+  ingressClassName: nginx

--- a/grafana/ingress.yaml
+++ b/grafana/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: grafana
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Grafana
@@ -26,3 +25,4 @@ spec:
             name: grafana
             port:
               number: 80
+  ingressClassName: nginx

--- a/hass/ingress.yaml
+++ b/hass/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     k8s-app: hass
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Home Assistant
@@ -28,3 +27,4 @@ spec:
             name: hass
             port:
               number: 8123
+  ingressClassName: nginx

--- a/meshcentral/ingress.yaml
+++ b/meshcentral/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: meshcentral
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Mesh Central
@@ -27,3 +26,4 @@ spec:
             name: meshcentral
             port:
               number: 80
+  ingressClassName: nginx

--- a/pihole/ingress.yaml
+++ b/pihole/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: pihole
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Pi Hole
@@ -26,3 +25,4 @@ spec:
             name: pihole
             port:
               number: 8000
+  ingressClassName: nginx

--- a/plexmediaserver/ingress.yaml
+++ b/plexmediaserver/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: plexmediaserver
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Plex
@@ -27,3 +26,4 @@ spec:
             name: plexmediaserver
             port:
               number: 32400
+  ingressClassName: nginx

--- a/prometheus/ingress.yaml
+++ b/prometheus/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: prometheus
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prometheus
@@ -26,3 +25,4 @@ spec:
             name: prometheus
             port:
               number: 9090
+  ingressClassName: nginx

--- a/prowlarr/ingress.yaml
+++ b/prowlarr/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: prowlarr
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prowlarr
@@ -27,3 +26,4 @@ spec:
             name: prowlarr
             port:
               number: 9696
+  ingressClassName: nginx

--- a/pushgateway/ingress.yaml
+++ b/pushgateway/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     k8s-app: pushgateway
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
@@ -24,3 +23,4 @@ spec:
             name: pushgateway
             port:
               number: 9091
+  ingressClassName: nginx

--- a/qbittorrent/ingress.yaml
+++ b/qbittorrent/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: qbittorrent
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: qBittorrent
@@ -28,3 +27,4 @@ spec:
             name: qbittorrent
             port:
               number: 8080
+  ingressClassName: nginx

--- a/radarr/ingress.yaml
+++ b/radarr/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: radarr
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Radarr
@@ -27,3 +26,4 @@ spec:
             name: radarr
             port:
               number: 7878
+  ingressClassName: nginx

--- a/sabnzbd/ingress.yaml
+++ b/sabnzbd/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: sabnzbd
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: SABnzbd
@@ -26,3 +25,4 @@ spec:
             name: sabnzbd
             port:
               number: 8080
+  ingressClassName: nginx

--- a/smokeping/ingress.yaml
+++ b/smokeping/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: smokeping
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Smokeping
@@ -26,3 +25,4 @@ spec:
             name: smokeping
             port:
               number: 80
+  ingressClassName: nginx

--- a/sonarr/ingress.yaml
+++ b/sonarr/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: sonarr
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Sonarr
@@ -29,3 +28,4 @@ spec:
             name: sonarr
             port:
               number: 8989
+  ingressClassName: nginx

--- a/tautulli/ingress.yaml
+++ b/tautulli/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     k8s-app: tautulli
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Tautulli
@@ -29,3 +28,4 @@ spec:
             name: tautulli
             port:
               number: 8181
+  ingressClassName: nginx

--- a/transmission/ingress.yaml
+++ b/transmission/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: transmission
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Transmission
@@ -28,3 +27,4 @@ spec:
             name: transmission
             port:
               number: 9091
+  ingressClassName: nginx

--- a/update-ingress-class.sh
+++ b/update-ingress-class.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Script to update ingress class from legacy to modern format using yq
+# Updates kubernetes.io/ingress.class: nginx to ingressClassName: nginx
+
+set -e
+
+echo "Updating ingress class annotations from legacy to modern format using yq..."
+
+# List of ingress files to update
+INGRESS_FILES=(
+    "autobrr/ingress.yaml"
+    "bazarr/ingress.yaml"
+    "channels/ingress.yaml"
+    "changedetection/ingress.yaml"
+    "cross-seed/ingress.yaml"
+    "grafana/ingress.yaml"
+    "hass/ingress.yaml"
+    "meshcentral/ingress.yaml"
+    "netatmo-exporter/ingress.yaml"
+    "pihole/ingress.yaml"
+    "plexmediaserver/ingress.yaml"
+    "prometheus/ingress.yaml"
+    "prowlarr/ingress.yaml"
+    "pushgateway/ingress.yaml"
+    "qbittorrent/ingress.yaml"
+    "radarr/ingress.yaml"
+    "sabnzbd/ingress.yaml"
+    "smokeping/ingress.yaml"
+    "sonarr/ingress.yaml"
+    "tautulli/ingress.yaml"
+    "transmission/ingress.yaml"
+)
+
+# Update each file
+for file in "${INGRESS_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        echo "Updating $file..."
+
+        # Use yq to:
+        # 1. Remove the legacy annotation
+        # 2. Add the modern ingressClassName to spec
+        yq eval '
+            del(.metadata.annotations."kubernetes.io/ingress.class") |
+            .spec.ingressClassName = "nginx"
+        ' -i "$file"
+
+        echo "✅ Updated $file"
+    else
+        echo "⚠️  File not found: $file"
+    fi
+done
+
+echo ""
+echo "✅ All ingress files updated!"
+echo ""
+echo "Changes made:"
+echo "- Removed: kubernetes.io/ingress.class: nginx"
+echo "- Added: ingressClassName: nginx (in spec section)"
+echo ""
+echo "Next steps:"
+echo "1. Review the changes: git diff"
+echo "2. Test the changes: kubectl apply --dry-run=client -f ."
+echo "3. Commit the changes: git add . && git commit -m 'Update ingress class to modern format'"


### PR DESCRIPTION
Replace deprecated kubernetes.io/ingress.class annotation with modern ingressClassName field for all custom ingress configurations.