### PR TITLE
Upgrade metrics-server to Chart 3.12.2 (v0.7.2)

### DIFF
--- a/metrics-server/Chart.yaml
+++ b/metrics-server/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: metrics-server-meta
+version: 0.1.0
+dependencies:
+- name: metrics-server
+  version: 3.8.2
+  repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/metrics-server/Chart.yaml
+++ b/metrics-server/Chart.yaml
@@ -4,5 +4,5 @@ name: metrics-server-meta
 version: 0.1.0
 dependencies:
 - name: metrics-server
-  version: 3.8.2
+  version: 3.12.2
   repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/metrics-server/helm/apiservice.yaml
+++ b/metrics-server/helm/apiservice.yaml
@@ -5,10 +5,10 @@ kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: metrics.k8s.io
@@ -17,5 +17,6 @@ spec:
   service:
     name: metrics-server
     namespace: default
+    port: 443
   version: v1beta1
   versionPriority: 100

--- a/metrics-server/helm/clusterrole-aggregated-reader.yaml
+++ b/metrics-server/helm/clusterrole-aggregated-reader.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: system:metrics-server-aggregated-reader
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/metrics-server/helm/clusterrole.yaml
+++ b/metrics-server/helm/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: system:metrics-server
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:

--- a/metrics-server/helm/clusterrolebinding-auth-delegator.yaml
+++ b/metrics-server/helm/clusterrolebinding-auth-delegator.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/metrics-server/helm/clusterrolebinding.yaml
+++ b/metrics-server/helm/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: system:metrics-server
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/metrics-server/helm/deployment.yaml
+++ b/metrics-server/helm/deployment.yaml
@@ -4,11 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server
+  namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -28,13 +29,18 @@ spec:
         - name: metrics-server
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
-          image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+            seccompProfile:
+              type: RuntimeDefault
+          image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
           imagePullPolicy: IfNotPresent
           args:
-            - --secure-port=4443
+            - --secure-port=10250
             - --cert-dir=/tmp
             - --kubelet-preferred-address-types=Hostname,InternalIP,ExternalIP
             - --kubelet-insecure-tls
@@ -43,7 +49,7 @@ spec:
           ports:
           - name: https
             protocol: TCP
-            containerPort: 4443
+            containerPort: 10250
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -63,6 +69,10 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
       volumes:
         - name: tmp
           emptyDir: {}

--- a/metrics-server/helm/rolebinding.yaml
+++ b/metrics-server/helm/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: metrics-server-auth-reader
   namespace: kube-system
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/metrics-server/helm/service.yaml
+++ b/metrics-server/helm/service.yaml
@@ -4,11 +4,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: metrics-server
+  namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -17,6 +18,7 @@ spec:
       port: 443
       protocol: TCP
       targetPort: https
+      appProtocol: https
   selector:
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server

--- a/metrics-server/helm/serviceaccount.yaml
+++ b/metrics-server/helm/serviceaccount.yaml
@@ -4,9 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metrics-server
+  namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.8.2
+    helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
-    app.kubernetes.io/version: "0.6.1"
+    app.kubernetes.io/version: "0.7.2"
     app.kubernetes.io/managed-by: Helm

--- a/metrics-server/render-helm.sh
+++ b/metrics-server/render-helm.sh
@@ -5,11 +5,13 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp
-helm template metrics-server metrics-server \
-	--repo https://kubernetes-sigs.github.io/metrics-server/ \
-	--version 3.8.2 \
+
+# Template using Chart.yaml
+helm_template metrics-server metrics-server \
 	--values values.yaml \
 	--output-dir tmp
 


### PR DESCRIPTION
- Add Chart.yaml for metrics-server\n- Upgrade metrics-server from Chart 3.8.2 (v0.6.1) to Chart 3.12.2 (v0.7.2)\n- Update Helm manifests for new image, registry, security context, resource requests, and port configuration