### PR TITLE
Fix renovate gitIgnoredAuthors syntax

### DIFF
--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
   version: 1.0.10
   repository: oci://8gears.container-registry.com/library
 - name: postgresql
-  version: 16.7.18
+  version: 16.7.19
   repository: https://charts.bitnami.com/bitnami

--- a/n8n/helm/postgres/primary/networkpolicy.yaml
+++ b/n8n/helm/postgres/primary/networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
     app.kubernetes.io/component: primary
 spec:
   podSelector:

--- a/n8n/helm/postgres/primary/pdb.yaml
+++ b/n8n/helm/postgres/primary/pdb.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
     app.kubernetes.io/component: primary
 spec:
   maxUnavailable: 1

--- a/n8n/helm/postgres/primary/statefulset.yaml
+++ b/n8n/helm/postgres/primary/statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
     app.kubernetes.io/component: primary
 spec:
   replicas: 1
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
         app.kubernetes.io/version: 17.5.0
-        helm.sh/chart: postgresql-16.7.18
+        helm.sh/chart: postgresql-16.7.19
         app.kubernetes.io/component: primary
     spec:
       serviceAccountName: n8n-postgres-postgresql

--- a/n8n/helm/postgres/primary/svc-headless.yaml
+++ b/n8n/helm/postgres/primary/svc-headless.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
     app.kubernetes.io/component: primary
   annotations:
 spec:

--- a/n8n/helm/postgres/primary/svc.yaml
+++ b/n8n/helm/postgres/primary/svc.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
     app.kubernetes.io/component: primary
 spec:
   type: ClusterIP

--- a/n8n/helm/postgres/serviceaccount.yaml
+++ b/n8n/helm/postgres/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/version: 17.5.0
-    helm.sh/chart: postgresql-16.7.18
+    helm.sh/chart: postgresql-16.7.19
 automountServiceAccountToken: false

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,5 @@
       "matchPaths": ["**/Chart.yaml"]
     }
   ],
-  "gitIgnoredAuthors": [
-    "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-  ]
+  "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"]
 }


### PR DESCRIPTION
Fix gitIgnoredAuthors to use email-only format instead of 'author <email>' syntax so Renovate properly ignores GitHub Actions commits.