### PR TITLE
Add Chart.yaml files and pin container images

### DIFF
--- a/0-nfs-client-provisioner/Chart.yaml
+++ b/0-nfs-client-provisioner/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: nfs-client-provisioner-meta
+version: 0.1.0
+dependencies:
+- name: nfs-subdir-external-provisioner
+  version: 4.0.18
+  repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner

--- a/0-nfs-client-provisioner/render-helm.sh
+++ b/0-nfs-client-provisioner/render-helm.sh
@@ -5,12 +5,13 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp helm
-helm template nfs-subdir-external-provisioner nfs-subdir-external-provisioner \
-	--repo https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner \
+# Template using Chart.yaml
+helm_template nfs-subdir-external-provisioner nfs-subdir-external-provisioner \
 	--include-crds \
-	--version 4.0.18 \
 	--values values.yaml \
 	--output-dir tmp
 

--- a/1password-connect/Chart.yaml
+++ b/1password-connect/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: 1password-connect-meta
+version: 0.1.0
+dependencies:
+- name: connect
+  version: 1.15.0
+  repository: https://1password.github.io/connect-helm-charts

--- a/1password-connect/helm/connect/templates/connect-deployment.yaml
+++ b/1password-connect/helm/connect/templates/connect-deployment.yaml
@@ -56,14 +56,14 @@ spec:
             - name: OP_HTTP_PORT
               value: "8080"
             - name: OP_LOG_LEVEL
-              value: "info"
+              value: "info"            
           readinessProbe:
             httpGet:
               path: /health
               scheme: HTTP
               port: 8080
             initialDelaySeconds: 15
-
+          
           livenessProbe:
             httpGet:
               path: /heartbeat
@@ -72,7 +72,7 @@ spec:
             failureThreshold: 3
             periodSeconds: 30
             initialDelaySeconds: 15
-
+          
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: shared-data
@@ -98,13 +98,13 @@ spec:
             - name: OP_BUS_PEERS
               value: localhost:11220
             - name: OP_LOG_LEVEL
-              value: "info"
+              value: "info"            
           readinessProbe:
             httpGet:
               path: /health
               port: 8081
             initialDelaySeconds: 15
-
+          
           livenessProbe:
             httpGet:
               path: /heartbeat
@@ -113,7 +113,7 @@ spec:
             failureThreshold: 3
             periodSeconds: 30
             initialDelaySeconds: 15
-
+          
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: shared-data

--- a/1password-connect/render-helm.sh
+++ b/1password-connect/render-helm.sh
@@ -5,10 +5,11 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm
-helm template connect connect \
-	--version 1.15.0 \
-	--repo https://1password.github.io/connect-helm-charts \
+# Template using Chart.yaml
+helm_template connect connect \
 	--namespace 1password \
 	--values values.yaml \
 	--output-dir helm

--- a/ddns-route53/kustomization.yaml
+++ b/ddns-route53/kustomization.yaml
@@ -11,3 +11,6 @@ labels:
     app.kubernetes.io/name: ddns-route53
     app.kubernetes.io/instance: ddns-route53
   includeSelectors: true
+images:
+- name: ghcr.io/crazy-max/ddns-route53
+  newTag: v2.13.0

--- a/descheduler/Chart.yaml
+++ b/descheduler/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: descheduler-meta
+version: 0.1.0
+dependencies:
+- name: descheduler
+  version: 0.29.0
+  repository: https://kubernetes-sigs.github.io/descheduler/

--- a/descheduler/render-helm.sh
+++ b/descheduler/render-helm.sh
@@ -5,11 +5,13 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp helm
-helm template descheduler descheduler \
-	--repo https://kubernetes-sigs.github.io/descheduler/ \
-	--version 0.29.0 \
+
+# Template using Chart.yaml
+helm_template descheduler descheduler \
 	--values values.yaml \
 	--output-dir tmp
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             pre-commit
             act
             mosquitto
+            skopeo
           ];
         };
       });

--- a/kube-state-metrics/Chart.yaml
+++ b/kube-state-metrics/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: kube-state-metrics-meta
+version: 0.1.0
+dependencies:
+- name: kube-state-metrics
+  version: 4.20.2
+  repository: https://prometheus-community.github.io/helm-charts

--- a/kube-state-metrics/helm/templates/clusterrolebinding.yaml
+++ b/kube-state-metrics/helm/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
+  labels:    
     helm.sh/chart: kube-state-metrics-4.20.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics

--- a/kube-state-metrics/helm/templates/deployment.yaml
+++ b/kube-state-metrics/helm/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: kube-state-metrics
   namespace: default
-  labels:
+  labels:    
     helm.sh/chart: kube-state-metrics-4.20.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
@@ -15,13 +15,13 @@ metadata:
     app.kubernetes.io/version: "2.6.0"
 spec:
   selector:
-    matchLabels:
+    matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/instance: kube-state-metrics
   replicas: 1
   template:
     metadata:
-      labels:
+      labels:        
         helm.sh/chart: kube-state-metrics-4.20.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics

--- a/kube-state-metrics/helm/templates/role.yaml
+++ b/kube-state-metrics/helm/templates/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
+  labels:    
     helm.sh/chart: kube-state-metrics-4.20.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics

--- a/kube-state-metrics/helm/templates/service.yaml
+++ b/kube-state-metrics/helm/templates/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: kube-state-metrics
   namespace: default
-  labels:
+  labels:    
     helm.sh/chart: kube-state-metrics-4.20.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
@@ -22,7 +22,7 @@ spec:
     protocol: TCP
     port: 8080
     targetPort: 8080
-
-  selector:
+  
+  selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics

--- a/kube-state-metrics/helm/templates/serviceaccount.yaml
+++ b/kube-state-metrics/helm/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
+  labels:    
     helm.sh/chart: kube-state-metrics-4.20.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics

--- a/kube-state-metrics/kustomization.yaml
+++ b/kube-state-metrics/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 labels:
 - pairs:
     app: kube-state-metrics
+  includeSelectors: true

--- a/kube-state-metrics/render-helm.sh
+++ b/kube-state-metrics/render-helm.sh
@@ -5,12 +5,13 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp helm
-helm template kube-state-metrics kube-state-metrics \
-	--repo https://prometheus-community.github.io/helm-charts \
+# Template using Chart.yaml
+helm_template kube-state-metrics kube-state-metrics \
 	--include-crds \
-	--version 4.20.2 \
 	--values values.yaml \
 	--output-dir tmp
 

--- a/pihole/kustomization.yaml
+++ b/pihole/kustomization.yaml
@@ -17,3 +17,6 @@ labels:
     app.kubernetes.io/name: pihole
     app.kubernetes.io/instance: pihole
   includeSelectors: true
+images:
+- name: pihole/pihole
+  newTag: 2025.07.1

--- a/reloader/Chart.yaml
+++ b/reloader/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: reloader-meta
+version: 0.1.0
+dependencies:
+- name: reloader
+  version: v1.0.71
+  repository: https://stakater.github.io/stakater-charts

--- a/reloader/helm/templates/clusterrole.yaml
+++ b/reloader/helm/templates/clusterrole.yaml
@@ -8,12 +8,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
     meta.helm.sh/release-name: "reloader"
   labels:
-    app: reloader-reloader
+    app: reloader
     chart: "reloader-1.0.71"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-  name: reloader-reloader-role
+  name: reloader-role
 rules:
   - apiGroups:
       - ""

--- a/reloader/helm/templates/clusterrolebinding.yaml
+++ b/reloader/helm/templates/clusterrolebinding.yaml
@@ -8,17 +8,17 @@ metadata:
     meta.helm.sh/release-namespace: "default"
     meta.helm.sh/release-name: "reloader"
   labels:
-    app: reloader-reloader
+    app: reloader
     chart: "reloader-1.0.71"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-  name: reloader-reloader-role-binding
+  name: reloader-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: reloader-reloader-role
+  name: reloader-role
 subjects:
   - kind: ServiceAccount
-    name: reloader-reloader
+    name: reloader
     namespace: default

--- a/reloader/helm/templates/deployment.yaml
+++ b/reloader/helm/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     meta.helm.sh/release-namespace: "default"
     meta.helm.sh/release-name: "reloader"
   labels:
-    app: reloader-reloader
+    app: reloader
     chart: "reloader-1.0.71"
     release: "reloader"
     heritage: "Helm"
@@ -15,19 +15,19 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.0.71
-  name: reloader-reloader
+  name: reloader
   namespace: default
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: reloader-reloader
+      app: reloader
       release: "reloader"
   template:
     metadata:
       labels:
-        app: reloader-reloader
+        app: reloader
         chart: "reloader-1.0.71"
         release: "reloader"
         heritage: "Helm"
@@ -39,7 +39,7 @@ spec:
       containers:
       - image: "ghcr.io/stakater/reloader:v1.0.71"
         imagePullPolicy: IfNotPresent
-        name: reloader-reloader
+        name: reloader
 
         ports:
         - name: http
@@ -68,4 +68,4 @@ spec:
       securityContext: 
         runAsNonRoot: true
         runAsUser: 65534
-      serviceAccountName: reloader-reloader
+      serviceAccountName: reloader

--- a/reloader/helm/templates/serviceaccount.yaml
+++ b/reloader/helm/templates/serviceaccount.yaml
@@ -7,10 +7,10 @@ metadata:
     meta.helm.sh/release-namespace: "default"
     meta.helm.sh/release-name: "reloader"
   labels:
-    app: reloader-reloader
+    app: reloader
     chart: "reloader-1.0.71"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-  name: reloader-reloader
+  name: reloader
   namespace: default

--- a/reloader/kustomization.yaml
+++ b/reloader/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - helm/templates/clusterrolebinding.yaml
 - helm/templates/deployment.yaml
 
-commonLabels:
-  app.kubernetes.io/name: reloader
-  app.kubernetes.io/instance: reloader
+labels:
+- pairs:
+    app.kubernetes.io/name: reloader
+    app.kubernetes.io/instance: reloader
+  includeSelectors: true

--- a/reloader/render-helm.sh
+++ b/reloader/render-helm.sh
@@ -5,12 +5,13 @@ set -eu -o pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR"
 
+source "$BASEDIR/../scripts/chart-version.sh"
+
 rm -rf helm tmp
 mkdir tmp helm
 touch values.yaml
-helm template reloader reloader \
-	--version v1.0.71 \
-	--repo https://stakater.github.io/stakater-charts \
+# Template using Chart.yaml
+helm_template reloader reloader \
 	--values values.yaml \
 	--output-dir tmp
 

--- a/reloader/values.yaml
+++ b/reloader/values.yaml
@@ -1,1 +1,6 @@
+---
 # intentionally left blank
+
+# Override the default naming to be more natural
+nameOverride: ''
+fullnameOverride: reloader


### PR DESCRIPTION
Add Chart.yaml files for services missing them to enable proper version tracking and Renovate integration. Also pin container images for ddns-route53 and pihole to specific versions.

Services updated with Chart.yaml:
- descheduler
- reloader  
- 0-nfs-client-provisioner
- kube-state-metrics
- 1password-connect

Image pinning:
- ddns-route53: v2.13.0
- pihole: 2025.07.1

Fixes:
- Fixed reloader resource naming (removed duplicate 'reloader-reloader')
- Updated render-helm.sh scripts to use version helper
- Added skopeo to dev environment for image verification