### PR TITLE
Upgrade reloader to v2.1.5

### DIFF
--- a/reloader/Chart.yaml
+++ b/reloader/Chart.yaml
@@ -4,5 +4,5 @@ name: reloader-meta
 version: 0.1.0
 dependencies:
 - name: reloader
-  version: v1.0.71
+  version: 2.1.5
   repository: https://stakater.github.io/stakater-charts

--- a/reloader/helm/templates/clusterrole.yaml
+++ b/reloader/helm/templates/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     meta.helm.sh/release-name: "reloader"
   labels:
     app: reloader
-    chart: "reloader-1.0.71"
+    chart: "reloader-2.1.5"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
@@ -36,16 +36,6 @@ rules:
       - update
       - patch
   - apiGroups:
-      - "extensions"
-    resources:
-      - deployments
-      - daemonsets
-    verbs:
-      - list
-      - get
-      - update
-      - patch
-  - apiGroups:
       - "batch"
     resources:
       - cronjobs
@@ -58,6 +48,9 @@ rules:
       - jobs
     verbs:
       - create
+      - delete
+      - list
+      - get
   - apiGroups:
       - ""
     resources:

--- a/reloader/helm/templates/clusterrolebinding.yaml
+++ b/reloader/helm/templates/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     meta.helm.sh/release-name: "reloader"
   labels:
     app: reloader
-    chart: "reloader-1.0.71"
+    chart: "reloader-2.1.5"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/reloader/helm/templates/deployment.yaml
+++ b/reloader/helm/templates/deployment.yaml
@@ -8,13 +8,13 @@ metadata:
     meta.helm.sh/release-name: "reloader"
   labels:
     app: reloader
-    chart: "reloader-1.0.71"
+    chart: "reloader-2.1.5"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
     group: com.stakater.platform
     provider: stakater
-    version: v1.0.71
+    version: v1.4.5
   name: reloader
   namespace: default
 spec:
@@ -28,19 +28,29 @@ spec:
     metadata:
       labels:
         app: reloader
-        chart: "reloader-1.0.71"
+        chart: "reloader-2.1.5"
         release: "reloader"
         heritage: "Helm"
         app.kubernetes.io/managed-by: "Helm"
         group: com.stakater.platform
         provider: stakater
-        version: v1.0.71
+        version: v1.4.5
     spec:
       containers:
-      - image: "ghcr.io/stakater/reloader:v1.0.71"
+      - image: "ghcr.io/stakater/reloader:v1.4.5"
         imagePullPolicy: IfNotPresent
         name: reloader
-
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+              divisor: '1'
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: '1'
         ports:
         - name: http
           containerPort: 9090
@@ -65,7 +75,11 @@ spec:
 
         securityContext:
           {}
+        args:
+          - "--log-level=info"
       securityContext: 
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: reloader

--- a/reloader/helm/templates/serviceaccount.yaml
+++ b/reloader/helm/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     meta.helm.sh/release-name: "reloader"
   labels:
     app: reloader
-    chart: "reloader-1.0.71"
+    chart: "reloader-2.1.5"
     release: "reloader"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"


### PR DESCRIPTION
Upgrade reloader from v1.0.71 to chart version 2.1.5 (application v1.4.5).

Key improvements:
- Added GOMAXPROCS and GOMEMLIMIT environment variables
- Enhanced security context with seccompProfile
- Removed deprecated extensions API group
- Added job recreation permissions
- Added log level configuration
- Core functionality verified with test deployment