### PR TITLE
Fix namespace copy-paste errors

### DIFF
--- a/1password-connect/namespace.yaml
+++ b/1password-connect/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: metallb-system
+  name: 1password

--- a/ingress-nginx/namespace.yaml
+++ b/ingress-nginx/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ingress-namespace
+  name: ingress-nginx


### PR DESCRIPTION
Fixed incorrect namespace names in namespace.yaml files:

- 1password-connect: metallb-system → 1password  
- ingress-nginx: ingress-namespace → ingress-nginx