### PR TITLE
Migrate flannel to Helm v0.27.1

### DIFF
--- a/0-flannel/Chart.yaml
+++ b/0-flannel/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: flannel-meta
+version: 0.1.0
+dependencies:
+- name: flannel
+  version: v0.24.3
+  repository: https://flannel-io.github.io/flannel

--- a/0-flannel/Chart.yaml
+++ b/0-flannel/Chart.yaml
@@ -4,5 +4,5 @@ name: flannel-meta
 version: 0.1.0
 dependencies:
 - name: flannel
-  version: v0.24.3
+  version: v0.27.1
   repository: https://flannel-io.github.io/flannel

--- a/0-flannel/helm/templates/config.yaml
+++ b/0-flannel/helm/templates/config.yaml
@@ -1,0 +1,38 @@
+---
+# Source: flannel/templates/config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: default
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "host-gw"
+      }
+    }

--- a/0-flannel/helm/templates/config.yaml
+++ b/0-flannel/helm/templates/config.yaml
@@ -9,26 +9,7 @@ metadata:
     tier: node
     app: flannel
 data:
-  cni-conf.json: |
-    {
-      "name": "cbr0",
-      "cniVersion": "0.3.1",
-      "plugins": [
-        {
-          "type": "flannel",
-          "delegate": {
-            "hairpinMode": true,
-            "isDefaultGateway": true
-          }
-        },
-        {
-          "type": "portmap",
-          "capabilities": {
-            "portMappings": true
-          }
-        }
-      ]
-    }
+  cni-conf.json: "{\n  \"name\": \"cbr0\",\n  \"cniVersion\": \"0.3.1\",\n  \"plugins\": [\n    {\n      \"type\": \"flannel\",\n      \"delegate\": {\n        \"hairpinMode\": true,\n        \"isDefaultGateway\": true\n      }\n    },\n    {\n      \"type\": \"portmap\",\n      \"capabilities\": {\n        \"portMappings\": true\n      }\n    }\n  ]\n}\n"
   net-conf.json: |
     {
       "Network": "10.244.0.0/16",

--- a/0-flannel/helm/templates/daemonset.yaml
+++ b/0-flannel/helm/templates/daemonset.yaml
@@ -1,0 +1,110 @@
+---
+# Source: flannel/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: default
+  labels:
+    tier: node
+    app: flannel
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni-plugin
+        image: docker.io/flannel/flannel-cni-plugin:v1.4.0-flannel1
+        command:
+        - cp
+        args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        volumeMounts:
+        - name: cni-plugin
+          mountPath: /opt/cni/bin
+      - name: install-cni
+        image: docker.io/flannel/flannel:v0.24.3
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+        image: docker.io/flannel/flannel:v0.24.3
+        command:
+        - "/opt/bin/flanneld"
+        - "--ip-masq"
+        - "--kube-subnet-mgr"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        volumeMounts:
+        - name: run
+          mountPath: /run/flannel
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+      volumes:
+      - name: run
+        hostPath:
+          path: /run/flannel
+      - name: cni-plugin
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: flannel-cfg
+        configMap:
+          name: kube-flannel-cfg
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate

--- a/0-flannel/helm/templates/daemonset.yaml
+++ b/0-flannel/helm/templates/daemonset.yaml
@@ -30,12 +30,12 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
+        - effect: NoSchedule
+          operator: Exists
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin
-        image: docker.io/flannel/flannel-cni-plugin:v1.4.0-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.7.1-flannel1
         command:
         - cp
         args:
@@ -46,7 +46,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.24.3
+        image: ghcr.io/flannel-io/flannel:v0.27.1
         command:
         - cp
         args:
@@ -60,15 +60,15 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.24.3
+        image: ghcr.io/flannel-io/flannel:v0.27.1
         command:
         - "/opt/bin/flanneld"
         - "--ip-masq"
         - "--kube-subnet-mgr"
         resources:
           requests:
-            cpu: "100m"
-            memory: "50Mi"
+            cpu: 100m
+            memory: 50Mi
         securityContext:
           privileged: false
           capabilities:
@@ -84,6 +84,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/0-flannel/helm/templates/rbac.yaml
+++ b/0-flannel/helm/templates/rbac.yaml
@@ -1,0 +1,48 @@
+---
+# Source: flannel/templates/rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - clustercidrs
+  verbs:
+  - list
+  - watch
+---
+# Source: flannel/templates/rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: default

--- a/0-flannel/helm/templates/rbac.yaml
+++ b/0-flannel/helm/templates/rbac.yaml
@@ -9,12 +9,8 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - nodes
+  - namespaces
   verbs:
   - get
   - list
@@ -25,13 +21,6 @@ rules:
   - nodes/status
   verbs:
   - patch
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - clustercidrs
-  verbs:
-  - list
-  - watch
 ---
 # Source: flannel/templates/rbac.yaml
 kind: ClusterRoleBinding

--- a/0-flannel/helm/templates/serviceaccount.yaml
+++ b/0-flannel/helm/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+# Source: flannel/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: default

--- a/0-flannel/kustomization.yaml
+++ b/0-flannel/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-flannel
+
+resources:
+- namespace.yaml
+- helm/templates/config.yaml
+- helm/templates/daemonset.yaml
+- helm/templates/rbac.yaml
+- helm/templates/serviceaccount.yaml

--- a/0-flannel/namespace.yaml
+++ b/0-flannel/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-flannel

--- a/0-flannel/render-helm.sh
+++ b/0-flannel/render-helm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$BASEDIR"
+
+# Source the chart-version.sh helper
+source "$BASEDIR/../scripts/chart-version.sh"
+
+rm -rf helm tmp
+mkdir tmp helm
+
+helm_template flannel flannel \
+	--create-namespace \
+	--values values.yaml \
+	--output-dir tmp
+
+mv tmp/*/* helm
+rmdir tmp/*
+rmdir tmp
+rm -rf helm/tests

--- a/0-flannel/values.yaml
+++ b/0-flannel/values.yaml
@@ -1,0 +1,11 @@
+---
+# Flannel configuration - only non-default values
+podCidr: 10.244.0.0/16
+
+flannel:
+  # Override default backend from vxlan to host-gw to match current deployment
+  backend: host-gw
+  # Override default tolerations to match current (only NoSchedule, not NoExecute)
+  tolerations:
+  - effect: NoSchedule
+    operator: Exists


### PR DESCRIPTION
Replace Ansible-based flannel deployment with Helm-based deployment using flannel-io/flannel chart v0.27.1. All network connectivity tests passed.