### PR TITLE
Upgrade kube-state-metrics to v5.37.0

### DIFF
--- a/kube-state-metrics/Chart.yaml
+++ b/kube-state-metrics/Chart.yaml
@@ -4,5 +4,5 @@ name: kube-state-metrics-meta
 version: 0.1.0
 dependencies:
 - name: kube-state-metrics
-  version: 4.20.2
+  version: 5.37.0
   repository: https://prometheus-community.github.io/helm-charts

--- a/kube-state-metrics/helm/templates/clusterrolebinding.yaml
+++ b/kube-state-metrics/helm/templates/clusterrolebinding.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-4.20.2
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.15.0"
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/kube-state-metrics/helm/templates/deployment.yaml
+++ b/kube-state-metrics/helm/templates/deployment.yaml
@@ -6,55 +6,81 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-4.20.2
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.15.0"
 spec:
   selector:
     matchLabels:      
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/instance: kube-state-metrics
   replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-4.20.2
+        helm.sh/chart: kube-state-metrics-5.37.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: kube-state-metrics
-        app.kubernetes.io/version: "2.6.0"
+        app.kubernetes.io/version: "2.15.0"
     spec:
+      automountServiceAccountToken: true
       hostNetwork: false
       serviceAccountName: kube-state-metrics
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
+        runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
-        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0"
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
         ports:
         - containerPort: 8080
           name: "http"
         livenessProbe:
+          failureThreshold: 3
           httpGet:
-            path: /healthz
+            httpHeaders:
+            path: /livez
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
+          failureThreshold: 3
           httpGet:
-            path: /
-            port: 8080
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true

--- a/kube-state-metrics/helm/templates/role.yaml
+++ b/kube-state-metrics/helm/templates/role.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-4.20.2
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.15.0"
   name: kube-state-metrics
 rules:
 
@@ -29,12 +29,12 @@ rules:
   - cronjobs
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   verbs: ["list", "watch"]
@@ -49,7 +49,7 @@ rules:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - ingresses
   verbs: ["list", "watch"]
@@ -57,6 +57,11 @@ rules:
 - apiGroups: ["batch"]
   resources:
   - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
   verbs: ["list", "watch"]
 
 - apiGroups: [""]
@@ -104,7 +109,7 @@ rules:
   - pods
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - replicasets
   verbs: ["list", "watch"]

--- a/kube-state-metrics/helm/templates/service.yaml
+++ b/kube-state-metrics/helm/templates/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-4.20.2
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.15.0"
   annotations:
     prometheus.io/scrape: 'true'
 spec:

--- a/kube-state-metrics/helm/templates/serviceaccount.yaml
+++ b/kube-state-metrics/helm/templates/serviceaccount.yaml
@@ -2,16 +2,15 @@
 # Source: kube-state-metrics/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-4.20.2
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: kube-state-metrics
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.15.0"
   name: kube-state-metrics
   namespace: default
-imagePullSecrets:
-  []


### PR DESCRIPTION
Upgrade from v4.20.2 to v5.37.0 (app v2.15.0) for Kubernetes v1.27 compatibility.

Key improvements:
- Security enhancements (runAsNonRoot, seccompProfile, readOnlyRootFilesystem)
- Updated health checks (/livez, /readyz)
- RBAC updates (removed extensions API, added leases support)
- Deployment improvements (rolling update strategy, revision history)
