### PR TITLE
Add HomeBox inventory management system

### DIFF
--- a/homebox/Chart.yaml
+++ b/homebox/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: homebox-meta
+version: 0.1.0
+dependencies:
+- name: homebox
+  version: 0.1.2
+  repository: https://bythehugo.github.io/homebox-helm/

--- a/homebox/externalsecret.yaml
+++ b/homebox/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homebox-postgres-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: homebox-postgresql
+    creationPolicy: Owner
+  data:
+  - secretKey: postgres-password
+    remoteRef:
+      key: homebox
+      property: postgres_password
+  - secretKey: admin-password
+    remoteRef:
+      key: homebox
+      property: postgres_admin_password

--- a/homebox/helm/homebox/deployment.yaml
+++ b/homebox/helm/homebox/deployment.yaml
@@ -1,0 +1,86 @@
+---
+# Source: homebox/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homebox
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homebox
+      app.kubernetes.io/instance: homebox
+  template:
+    metadata:
+      annotations:
+        checksum/secret: b2428aa66152458dfb56bf8e299c8b639ad7d516193c2ea10e745547f03f77f5
+      labels:
+        helm.sh/chart: homebox-0.1.2
+        app.kubernetes.io/name: homebox
+        app.kubernetes.io/instance: homebox
+        app.kubernetes.io/version: "0.20.2"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: homebox
+      securityContext:
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: homebox
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          image: "sysadminsmedia/homebox:0.20.2"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: homebox
+          ports:
+            - name: http
+              containerPort: 7745
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 300m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: "/data"
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "homebox-data"

--- a/homebox/helm/homebox/ingress.yaml
+++ b/homebox/helm/homebox/ingress.yaml
@@ -1,0 +1,36 @@
+---
+# Source: homebox/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homebox
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/description: Inventory and Organization System
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home Lab
+    gethomepage.dev/icon: homebox.png
+    gethomepage.dev/name: HomeBox
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "homebox.k.oneill.net"
+      secretName: homebox-tls
+  rules:
+    - host: "homebox.k.oneill.net"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homebox
+                port:
+                  number: 7745

--- a/homebox/helm/homebox/pvc.yaml
+++ b/homebox/helm/homebox/pvc.yaml
@@ -1,0 +1,19 @@
+---
+# Source: homebox/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homebox-data
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  storageClassName: nfs
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/homebox/helm/homebox/secrets.yaml
+++ b/homebox/helm/homebox/secrets.yaml
@@ -1,0 +1,52 @@
+---
+# Source: homebox/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: homebox
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+stringData:
+  # DATABASE
+  HBOX_DATABASE_DRIVER: "postgres"
+  HBOX_DATABASE_HOST: "homebox-postgresql.default.svc"
+  HBOX_DATABASE_PORT: "5432"
+  HBOX_DATABASE_USERNAME: "homebox"
+  HBOX_DATABASE_PASSWORD: "homebox-password"
+  HBOX_DATABASE_DATABASE: "homebox"
+  HBOX_DATABASE_SSL_MODE: "disable"
+
+  # VARIOUS
+  HBOX_LABEL_MAKER_ADDITIONAL_INFORMATION: ""
+  HBOX_LABEL_MAKER_DYNAMIC_LENGTH: "true"
+  HBOX_LABEL_MAKER_FONT_SIZE: "32"
+  HBOX_LABEL_MAKER_HEIGHT: "200"
+  HBOX_LABEL_MAKER_PADDING: "32"
+  HBOX_LABEL_MAKER_PRINT_COMMAND: ""
+  HBOX_LABEL_MAKER_WIDTH: "526"
+  HBOX_LOG_FORMAT: "text"
+  HBOX_LOG_LEVEL: "info"
+  HBOX_MAILER_FROM: ""
+  HBOX_MAILER_HOST: ""
+  HBOX_MAILER_PASSWORD: ""
+  HBOX_MAILER_PORT: "587"
+  HBOX_MAILER_USERNAME: ""
+  HBOX_MODE: "production"
+  HBOX_OPTIONS_ALLOW_ANALYTICS: "false"
+  HBOX_OPTIONS_ALLOW_REGISTRATION: "true"
+  HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID: "true"
+  HBOX_OPTIONS_CHECK_GITHUB_RELEASE: "true"
+  HBOX_STORAGE_DATA: "/data"
+  HBOX_THUMBNAIL_ENABLED: "true"
+  HBOX_THUMBNAIL_HEIGHT: "500"
+  HBOX_THUMBNAIL_WIDTH: "500"
+  HBOX_WEB_IDLE_TIMEOUT: "30s"
+  HBOX_WEB_MAX_FILE_UPLOAD: "10"
+  HBOX_WEB_PORT: "7745"
+  HBOX_WEB_READ_TIMEOUT: "10s"
+  HBOX_WEB_WRITE_TIMEOUT: "10s"
+  TZ: "America/New_York"

--- a/homebox/helm/homebox/service.yaml
+++ b/homebox/helm/homebox/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: homebox/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: homebox
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7745
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox

--- a/homebox/helm/homebox/serviceaccount.yaml
+++ b/homebox/helm/homebox/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: homebox/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homebox
+  labels:
+    helm.sh/chart: homebox-0.1.2
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/version: "0.20.2"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true

--- a/homebox/helm/postgresql/primary/statefulset.yaml
+++ b/homebox/helm/postgresql/primary/statefulset.yaml
@@ -1,0 +1,190 @@
+---
+# Source: homebox/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: homebox-postgresql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 17.5.0
+    helm.sh/chart: postgresql-16.7.13
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: homebox-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: homebox
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: homebox-postgresql
+      labels:
+        app.kubernetes.io/instance: homebox
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: postgresql-16.7.13
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: homebox-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: homebox
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnami/postgresql:17.5.0-debian-12-r12
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "homebox"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/postgres-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/admin-password
+            - name: POSTGRES_DATABASE
+              value: "homebox"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "homebox" -d "dbname=homebox" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "homebox" -d "dbname=homebox" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: homebox-postgresql
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"
+        storageClassName: nfs

--- a/homebox/helm/postgresql/primary/svc-headless.yaml
+++ b/homebox/helm/postgresql/primary/svc-headless.yaml
@@ -1,0 +1,30 @@
+---
+# Source: homebox/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: homebox-postgresql-hl
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 17.5.0
+    helm.sh/chart: postgresql-16.7.13
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/homebox/helm/postgresql/primary/svc.yaml
+++ b/homebox/helm/postgresql/primary/svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: homebox/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: homebox-postgresql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 17.5.0
+    helm.sh/chart: postgresql-16.7.13
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/homebox/helm/postgresql/serviceaccount.yaml
+++ b/homebox/helm/postgresql/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: homebox/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homebox-postgresql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: homebox
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 17.5.0
+    helm.sh/chart: postgresql-16.7.13
+automountServiceAccountToken: false

--- a/homebox/kustomization.yaml
+++ b/homebox/kustomization.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # External secrets
+- externalsecret.yaml
+
+  # HomeBox resources
+- helm/homebox/deployment.yaml
+- helm/homebox/secrets.yaml
+- helm/homebox/service.yaml
+- helm/homebox/pvc.yaml
+- helm/homebox/serviceaccount.yaml
+- helm/homebox/ingress.yaml
+
+  # PostgreSQL resources
+- helm/postgresql/serviceaccount.yaml
+- helm/postgresql/primary/svc.yaml
+- helm/postgresql/primary/statefulset.yaml
+- helm/postgresql/primary/svc-headless.yaml
+
+patches:
+- target:
+    kind: Deployment
+    name: homebox
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: HBOX_DATABASE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: homebox-postgresql
+            key: postgres-password
+# Add labels for metrics
+labels:
+- pairs:
+    app.kubernetes.io/name: homebox
+    app.kubernetes.io/instance: homebox

--- a/homebox/render-helm.sh
+++ b/homebox/render-helm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$BASEDIR"
+
+source "$BASEDIR/../scripts/chart-version.sh"
+
+rm -rf helm tmp
+mkdir tmp helm
+
+# Render homebox chart
+helm_template homebox homebox --include-crds --values values.yaml --output-dir tmp
+
+mv tmp/*/* helm
+mv helm/templates helm/homebox
+mv helm/charts/postgresql/templates helm/postgresql
+rm -rf helm/charts
+rmdir tmp/*
+rmdir tmp
+rm -rf helm/homebox/tests

--- a/homebox/values.yaml
+++ b/homebox/values.yaml
@@ -1,0 +1,54 @@
+---
+# HomeBox configuration
+# Only override non-default settings
+
+global:
+  defaultStorageClass: nfs
+
+env:
+  TZ: America/New_York
+  HBOX_OPTIONS_ALLOW_REGISTRATION: true
+
+  # Database configuration for PostgreSQL
+  HBOX_DATABASE_DRIVER: postgres
+  HBOX_DATABASE_HOST: homebox-postgresql
+  HBOX_DATABASE_PORT: 5432
+  HBOX_DATABASE_NAME: homebox
+  HBOX_DATABASE_USER: homebox
+  HBOX_DATABASE_SSL_MODE: disable
+
+# Ingress configuration
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: HomeBox
+    gethomepage.dev/description: Inventory and Organization System
+    gethomepage.dev/group: Home Lab
+    gethomepage.dev/icon: homebox.png
+  hosts:
+  - host: homebox.k.oneill.net
+    paths:
+    - path: /
+      pathType: Prefix
+  tls:
+  - secretName: homebox-tls
+    hosts:
+    - homebox.k.oneill.net
+
+# PostgreSQL configuration with external secrets
+postgresql:
+  auth:
+    username: homebox
+    database: homebox
+    existingSecret: homebox-postgresql
+    secretKeys:
+      adminPasswordKey: admin-password
+      userPasswordKey: postgres-password
+  primary:
+    networkPolicy:
+      enabled: false
+    pdb:
+      create: false


### PR DESCRIPTION
Add HomeBox inventory and organization system using homebox-helm/homebox chart.

- PostgreSQL database with external secrets from 1Password
- Ingress with TLS at https://homebox.k.oneill.net
- Registration enabled for initial setup