### PR TITLE
Add control plane affinity for MeshCentral and nginx ingress

### DIFF
--- a/ingress-nginx/helm/controller-deployment.yaml
+++ b/ingress-nginx/helm/controller-deployment.yaml
@@ -116,7 +116,18 @@ spec:
               memory: 90Mi
       nodeSelector: 
         kubernetes.io/os: linux
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       affinity: 
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 100
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:

--- a/ingress-nginx/values.yaml
+++ b/ingress-nginx/values.yaml
@@ -13,7 +13,18 @@ controller:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
   affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100

--- a/meshcentral/deploy.yaml
+++ b/meshcentral/deploy.yaml
@@ -15,6 +15,18 @@ spec:
         app.kubernetes.io/name: meshcentral
         app.kubernetes.io/instance: meshcentral
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       containers:
       - name: meshcentral
         image: typhonragewind/meshcentral


### PR DESCRIPTION
- Add tolerations for node-role.kubernetes.io/control-plane taint

- Add preferred node affinity for control plane nodes

- Preserve existing pod anti-affinity for nginx ingress replicas