### PR TITLE
Add SpiderDuo KVM to Homepage services

### DIFF
--- a/homepage/services.yaml
+++ b/homepage/services.yaml
@@ -4,3 +4,8 @@
       href: https://upspi.oneill.net
       description: NUT Web UI
       icon: peanut.png
+- Home Lab:
+  - SpiderDuo KVM:
+      href: https://spiderduo.oneill.net
+      description: SpiderDuo KVM
+      icon: mdi-spider-outline


### PR DESCRIPTION
Add SpiderDuo KVM service to Homepage dashboard.

- Add SpiderDuo KVM to Home Lab group
- Configure with mdi-spider-outline icon
- Accessible at https://spiderduo.oneill.net