### PR TITLE
Fix QBT pin

### DIFF
--- a/qbittorrent/deployment.yaml
+++ b/qbittorrent/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: qbittorrent
-        image: linuxserver/qbittorrent
+        image: qbittorrent
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/qbittorrent/kustomization.yaml
+++ b/qbittorrent/kustomization.yaml
@@ -10,7 +10,8 @@ resources:
 - ingress.yaml
 
 images:
-- name: linuxserver/qbittorrent
+- name: qbittorrent
+  newName: ghcr.io/linuxserver/qbittorrent
   newTag: 5.1.2
 
 labels:


### PR DESCRIPTION
This was still using the dockerhub image, not the newer GHCR