### PR TITLE
Migrate Caseta certificates to external secrets

### DIFF
--- a/hass/deploy.yaml
+++ b/hass/deploy.yaml
@@ -64,8 +64,22 @@ spec:
           readOnly: true
       volumes:
       - name: config-map
-        configMap:
-          name: hass
+        projected:
+          sources:
+          - configMap:
+              name: hass
+          - secret:
+              name: hass-caseta-certificates
+              items:
+              - key: caseta-bridge.crt
+                path: caseta-bridge.crt
+                mode: 0644
+              - key: caseta.crt
+                path: caseta.crt
+                mode: 0644
+              - key: caseta.key
+                path: caseta.key
+                mode: 0600
       - name: config
         persistentVolumeClaim:
           claimName: hass-config

--- a/hass/externalsecret.yaml
+++ b/hass/externalsecret.yaml
@@ -51,3 +51,18 @@ spec:
   dataFrom:
   - extract:
       key: hass-secrets
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hass-caseta-certificates
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: hass-caseta-certificates
+  dataFrom:
+  - extract:
+      key: hass-caseta-certificates


### PR DESCRIPTION
Move Caseta certificates (caseta.key, caseta.crt, caseta-bridge.crt) from configmap to external secrets using 1Password CLI. Update deployment to mount certificates via projected volume. Fix certificate formatting issues with proper newlines.