### PR TITLE
Update pushgateway image to v1.11.1

### DIFF
--- a/pushgateway/deploy.yaml
+++ b/pushgateway/deploy.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: pushgateway
-        image: prom/pushgateway:v0.4.0
+        image: prom/pushgateway:v1.11.1
         ports:
         - name: web
           containerPort: 9091


### PR DESCRIPTION
Updates pushgateway from v0.4.0 to v1.11.1 to resolve ImagePullBackOff error caused by deprecated Docker schema 1 manifests. The new version includes security fixes and native histogram support.