### PR TITLE
Remove thermostat from Prometheus blackbox monitoring

### DIFF
--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -45,7 +45,6 @@ scrape_configs:
     - veraplus.oneill.net
     - udmp.oneill.net
     - basement-guardian.oneill.net
-    - infinity-thermostat.oneill.net
   relabel_configs:
   - source_labels: [__address__]
     target_label: __param_target


### PR DESCRIPTION
Removes infinity-thermostat.oneill.net from blackbox monitoring as it's no longer needed.