### PR TITLE
Apply yamlfix formatting fixes

### DIFF
--- a/0-clusterwide/priorityclass-high-priority.yaml
+++ b/0-clusterwide/priorityclass-high-priority.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
+
 metadata:
   name: high-priority
+
 value: 1000000
 globalDefault: false
 description: This priority class should be used for high priority pods.

--- a/0-flannel/namespace.yaml
+++ b/0-flannel/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: kube-flannel

--- a/0-nfs-client-provisioner/kustomization.yaml
+++ b/0-nfs-client-provisioner/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - helm/templates/deployment.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: 0-nfs-client-provisioner
     app.kubernetes.io/instance: 0-nfs-client-provisioner

--- a/0-nfs-client-provisioner/values.yaml
+++ b/0-nfs-client-provisioner/values.yaml
@@ -1,10 +1,12 @@
 ---
 image:
   tag: v4.0.2
+
 nfs:
   server: fs2.oneill.net
   path: /volume1/k8s-pv
   volumeName: nfs-client-root
+
 storageClass:
   name: nfs
   provisionerName: nfs

--- a/1password-connect/namespace.yaml
+++ b/1password-connect/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: 1password

--- a/alertmanager/config.template.yaml
+++ b/alertmanager/config.template.yaml
@@ -5,6 +5,7 @@ global:
   smtp_from: clayton@oneill.net
   smtp_auth_username: clayton.oneill@gmail.com
   smtp_auth_password: '{{ .Env.SMTP_PASSWORD }}'
+
 # # The directory from which notification templates are read.
 templates:
 - /etc/alertmanager-templates/*.tmpl
@@ -31,6 +32,7 @@ route:
   - match:
       severity: email
     receiver: default
+
 receivers:
 - name: default
   email_configs:

--- a/alertmanager/deploy.yaml
+++ b/alertmanager/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: alertmanager
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/alertmanager/externalsecret.yaml
+++ b/alertmanager/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: alertmanager
+
 spec:
   secretStoreRef:
     name: production

--- a/alertmanager/ingress.yaml
+++ b/alertmanager/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: alertmanager
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: Alertmanager
     gethomepage.dev/group: Monitoring
     gethomepage.dev/icon: alertmanager.png
+
 spec:
   ingressClassName: nginx
   tls:

--- a/alertmanager/kustomization.yaml
+++ b/alertmanager/kustomization.yaml
@@ -10,10 +10,12 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/instance: alertmanager
   includeSelectors: true
+
 configMapGenerator:
 - name: alertmanager
   files:

--- a/alertmanager/pvc.yaml
+++ b/alertmanager/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: alertmanager-data
   labels:
     k8s-app: alertmanager
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/alertmanager/service.yaml
+++ b/alertmanager/service.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
     name: alertmanager
   name: alertmanager
+
 spec:
   selector:
     app.kubernetes.io/name: alertmanager

--- a/argocd/namespace.yaml
+++ b/argocd/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: argocd

--- a/autobrr/deployment.yaml
+++ b/autobrr/deployment.yaml
@@ -1,11 +1,13 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: autobrr
   annotations:
     reloader.stakater.com/auto: 'true'
     secret.reloader.stakater.com/reload: iscsi-chap-secret
+
 spec:
   strategy:
     type: Recreate

--- a/autobrr/ingress.yaml
+++ b/autobrr/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: autobrr
   labels:
@@ -12,6 +13,7 @@ metadata:
     gethomepage.dev/description: IRC Torrent Watcher
     gethomepage.dev/group: Media Tools
     gethomepage.dev/icon: autobrr.png
+
 spec:
   tls:
   - hosts:

--- a/autobrr/kustomization.yaml
+++ b/autobrr/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: autobrr
     app.kubernetes.io/instance: autobrr

--- a/autobrr/service.yaml
+++ b/autobrr/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: autobrr
   labels:
     app: autobrr
+
 spec:
   ports:
   - port: 7474

--- a/awair-exporter/deploy.yaml
+++ b/awair-exporter/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: awair-exporter
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/awair-exporter/externalsecret.yaml
+++ b/awair-exporter/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: awair-exporter
+
 spec:
   secretStoreRef:
     name: production

--- a/awair-exporter/kustomization.yaml
+++ b/awair-exporter/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: awair-exporter
     app.kubernetes.io/instance: awair-exporter

--- a/awair-exporter/service.yaml
+++ b/awair-exporter/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: awair-exporter
+
 spec:
   selector:
     app.kubernetes.io/name: awair-exporter

--- a/bazarr/deployment.yaml
+++ b/bazarr/deployment.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: bazarr
   labels:
     app: bazarr
+
 spec:
   strategy:
     type: Recreate

--- a/bazarr/ingress.yaml
+++ b/bazarr/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: bazarr
   labels:
@@ -12,6 +13,7 @@ metadata:
     gethomepage.dev/group: Media Tools
     gethomepage.dev/icon: bazarr.png
     gethomepage.dev/description: Subtitle Downloader
+
 spec:
   tls:
   - hosts:

--- a/bazarr/kustomization.yaml
+++ b/bazarr/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: bazarr
     app.kubernetes.io/instance: bazarr

--- a/bazarr/pvc.yaml
+++ b/bazarr/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: bazarr-config
   labels:
     k8s-app: bazarr
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/bazarr/service.yaml
+++ b/bazarr/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: bazarr
   labels:
     app: bazarr
+
 spec:
   ports:
   - port: 6767

--- a/blackbox-exporter/deploy.yaml
+++ b/blackbox-exporter/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: exporter
+
 spec:
   replicas: 1
   selector:

--- a/blackbox-exporter/kustomization.yaml
+++ b/blackbox-exporter/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: blackbox-exporter
+
 configMapGenerator:
 - name: config
   files:

--- a/blackbox-exporter/service.yaml
+++ b/blackbox-exporter/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: exporter
+
 spec:
   selector:
     app.kubernetes.io/name: blackbox-exporter

--- a/cert-manager/externalsecret.yaml
+++ b/cert-manager/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: cert-manager
+
 spec:
   secretStoreRef:
     name: production

--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -58,5 +58,6 @@ patches:
     name: cert-manager-cainjector
 
 labels:
+
 - pairs:
     app: cert-manager

--- a/cert-manager/letsencrypt.yaml
+++ b/cert-manager/letsencrypt.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
+
 metadata:
   name: letsencrypt
+
 spec:
   acme:
     email: clayton@oneill.net

--- a/cert-manager/self-signed.yaml
+++ b/cert-manager/self-signed.yaml
@@ -1,16 +1,21 @@
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
+
 metadata:
   name: selfsigned-issuer
+
 spec:
   selfSigned: {}
+
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
+
 metadata:
   name: my-selfsigned-ca
   namespace: cert-manager
+
 spec:
   isCA: true
   commonName: my-selfsigned-ca
@@ -23,11 +28,14 @@ spec:
     name: selfsigned-issuer
     kind: ClusterIssuer
     group: cert-manager.io
+
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
+
 metadata:
   name: my-ca-issuer
+
 spec:
   ca:
     secretName: root-secret

--- a/changedetection/deploy.yaml
+++ b/changedetection/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: changedetection
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   strategy:

--- a/changedetection/ingress.yaml
+++ b/changedetection/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: changedetection
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: ChangeDetection
     gethomepage.dev/group: Miscellaneous
     gethomepage.dev/icon: changedetection
+
 spec:
   ingressClassName: nginx
   tls:

--- a/changedetection/kustomization.yaml
+++ b/changedetection/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - pvc.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: changedetection
     app.kubernetes.io/instance: changedetection

--- a/changedetection/pvc.yaml
+++ b/changedetection/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: changedetection-data
   labels:
     k8s-app: changedetection
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/changedetection/service.yaml
+++ b/changedetection/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   labels:
     name: changedetection
   name: changedetection
+
 spec:
   selector:
     app.kubernetes.io/name: changedetection

--- a/channels/deploy.yaml
+++ b/channels/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: channels-dvr
+
 spec:
   replicas: 1
   selector:
@@ -24,6 +26,7 @@ spec:
       - name: channels
         image: fancybits/channels-dvr:tve
         imagePullPolicy: Always
+
 #        command: ['sleep', 'infinity']
         env:
         - name: TZ

--- a/channels/ingress.yaml
+++ b/channels/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: channels
   annotations:
@@ -10,6 +11,7 @@ metadata:
     gethomepage.dev/description: Channels DVR
     gethomepage.dev/group: Media
     gethomepage.dev/icon: channels-dvr.png
+
 spec:
   tls:
   - hosts:

--- a/channels/kustomization.yaml
+++ b/channels/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: channels
     app.kubernetes.io/instance: channels

--- a/channels/pvc.yaml
+++ b/channels/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: channels-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/channels/service.yaml
+++ b/channels/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: channels
   annotations:
     metallb.io/allow-shared-ip: channels
+
 spec:
   type: LoadBalancer
   ports:

--- a/cluster-backup/cronjob.yaml
+++ b/cluster-backup/cronjob.yaml
@@ -1,9 +1,11 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: cluster-backup
   namespace: kube-system
+
 spec:
   schedule: 0 */12 * * *
   concurrencyPolicy: Forbid

--- a/cluster-backup/kustomization.yaml
+++ b/cluster-backup/kustomization.yaml
@@ -7,10 +7,12 @@ resources:
 - cronjob.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: cluster-backup
     app.kubernetes.io/instance: cluster-backup
   includeSelectors: true
+
 configMapGenerator:
 - name: cluster-backup
   files:

--- a/cross-seed/deployment.yaml
+++ b/cross-seed/deployment.yaml
@@ -1,11 +1,13 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: cross-seed
   annotations:
     reloader.stakater.com/auto: 'true'
     secret.reloader.stakater.com/reload: iscsi-chap-secret,cross-seed-secrets
+
 spec:
   strategy:
     type: Recreate

--- a/cross-seed/externalsecret.yaml
+++ b/cross-seed/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: cross-seed-secrets
+
 spec:
   secretStoreRef:
     name: production

--- a/cross-seed/ingress.yaml
+++ b/cross-seed/ingress.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: cross-seed
   labels:
     app: cross-seed
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+
 spec:
   tls:
   - hosts:

--- a/cross-seed/kustomization.yaml
+++ b/cross-seed/kustomization.yaml
@@ -16,6 +16,7 @@ configMapGenerator:
   - config.js
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: cross-seed
     app.kubernetes.io/instance: cross-seed

--- a/cross-seed/pvc.yaml
+++ b/cross-seed/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: cross-seed-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/cross-seed/service.yaml
+++ b/cross-seed/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: cross-seed
   labels:
     app: cross-seed
+
 spec:
   ports:
   - port: 2468

--- a/ddns-route53/deploy.yaml
+++ b/ddns-route53/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: ddns-route53
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   strategy:

--- a/ddns-route53/externalsecret.yaml
+++ b/ddns-route53/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: ddns-route53-fnord
+
 spec:
   secretStoreRef:
     name: production
@@ -11,11 +13,14 @@ spec:
   dataFrom:
   - extract:
       key: ddns-route53-fnord
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: ddns-route53-oneill
+
 spec:
   secretStoreRef:
     name: production

--- a/ddns-route53/kustomization.yaml
+++ b/ddns-route53/kustomization.yaml
@@ -7,10 +7,12 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: ddns-route53
     app.kubernetes.io/instance: ddns-route53
   includeSelectors: true
+
 images:
 - name: ghcr.io/crazy-max/ddns-route53
   newTag: v2.13.0

--- a/descheduler/kustomization.yaml
+++ b/descheduler/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
 - helm/templates/configmap.yaml
 
 labels:
+
 - pairs:
     app: descheduler

--- a/descheduler/values.yaml
+++ b/descheduler/values.yaml
@@ -1,6 +1,7 @@
 ---
 schedule: 17 7 * * *
 deschedulerPolicyAPIVersion: descheduler/v1alpha2
+
 deschedulerPolicy:
   maxNoOfPodsToEvictPerNode: 2
   evictLocalStoragePods: true

--- a/external-dns/externalsecret.yaml
+++ b/external-dns/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: external-dns
+
 spec:
   secretStoreRef:
     name: production

--- a/external-dns/kustomization.yaml
+++ b/external-dns/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 
 commonLabels:
   app: external-dns
+
 patches:
 - patch: |-
     apiVersion: apps/v1

--- a/external-secrets/clusterstore.yaml
+++ b/external-secrets/clusterstore.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
+
 metadata:
   name: production
+
 spec:
   provider:
     onepassword:

--- a/external-secrets/iscsi-external-secret.yaml
+++ b/external-secrets/iscsi-external-secret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
+
 metadata:
   name: iscsi-chap-secret
+
 spec:
   externalSecretName: iscsi-chap-secret
   externalSecretSpec:

--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -38,8 +38,10 @@ resources:
 - iscsi-external-secret.yaml
 
 labels:
+
 - pairs:
     app: external-secrets
+
 secretGenerator:
 - name: secrets
   options:

--- a/external-secrets/namespace.yaml
+++ b/external-secrets/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: external-secrets

--- a/goldilocks/kustomization.yaml
+++ b/goldilocks/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
 - helm/templates/dashboard-serviceaccount.yaml
 
 labels:
+
 - pairs:
     app: goldilocks

--- a/goldilocks/values.yaml
+++ b/goldilocks/values.yaml
@@ -7,6 +7,7 @@ controller:
       memory: 256Mi
   flags:
     on-by-default: true
+
 dashboard:
   replicaCount: 1
   resources:

--- a/got-your-back/cronjob-full.yaml
+++ b/got-your-back/cronjob-full.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: got-your-back-full
+
 spec:
   schedule: 18 9 * * 0
   concurrencyPolicy: Forbid

--- a/got-your-back/cronjob-incremental.yaml
+++ b/got-your-back/cronjob-incremental.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: got-your-back-incremental
+
 spec:
   schedule: 13 */4 * * *
   concurrencyPolicy: Forbid

--- a/got-your-back/externalsecret.yaml
+++ b/got-your-back/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: got-your-back
+
 spec:
   secretStoreRef:
     name: production

--- a/got-your-back/kustomization.yaml
+++ b/got-your-back/kustomization.yaml
@@ -9,10 +9,12 @@ resources:
 - pvc.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: got-your-back
     app.kubernetes.io/instance: got-your-back
   includeSelectors: true
+
 configMapGenerator:
 - name: run-script
   files:

--- a/got-your-back/pvc.yaml
+++ b/got-your-back/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: got-your-back-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/grafana/deploy.yaml
+++ b/grafana/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: grafana
+
 spec:
   replicas: 1
   selector:

--- a/grafana/ingress.yaml
+++ b/grafana/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: grafana
   annotations:
@@ -9,6 +10,7 @@ metadata:
     gethomepage.dev/name: Grafana
     gethomepage.dev/group: Monitoring
     gethomepage.dev/icon: grafana.png
+
 spec:
   tls:
   - hosts:

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana

--- a/grafana/pvc.yaml
+++ b/grafana/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: grafana-storage
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/grafana/service.yaml
+++ b/grafana/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: grafana
+
 spec:
   # In a production setup, we recommend accessing Grafana through an external Loadbalancer
   # or through a public IP.

--- a/hass/deploy.yaml
+++ b/hass/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: hass
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   strategy:

--- a/hass/externalsecret.yaml
+++ b/hass/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: hass-ssh-key
+
 spec:
   secretStoreRef:
     name: production
@@ -21,11 +23,14 @@ spec:
     remoteRef:
       key: hass-ssh-key
       property: public key
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: alertmanager
+
 spec:
   secretStoreRef:
     name: production
@@ -36,11 +41,14 @@ spec:
     remoteRef:
       key: alertmanager
       property: smtp-password
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: hass-secrets
+
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -51,11 +59,14 @@ spec:
   dataFrom:
   - extract:
       key: hass-secrets
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: hass-caseta-certificates
+
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/hass/ingress.yaml
+++ b/hass/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: hass
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: Home Assistant
     gethomepage.dev/group: Miscellaneous
     gethomepage.dev/icon: home-assistant.png
+
 spec:
   tls:
   - hosts:

--- a/hass/kustomization.yaml
+++ b/hass/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: hass
     app.kubernetes.io/instance: hass

--- a/hass/mysql-deploy.yaml
+++ b/hass/mysql-deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: hass-mysql
+
 spec:
   strategy:
     type: Recreate

--- a/hass/mysql-pvc.yaml
+++ b/hass/mysql-pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: hass-mysql
   labels:
     k8s-app: hass-mysql
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/hass/mysql-service.yaml
+++ b/hass/mysql-service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   labels:
     name: hass-mysql
   name: hass-mysql
+
 spec:
   selector:
     app.kubernetes.io/name: hass

--- a/hass/pvc.yaml
+++ b/hass/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: hass-config
   labels:
     k8s-app: hass-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/hass/service.yaml
+++ b/hass/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   labels:
     name: hass
   name: hass
+
 spec:
   selector:
     app.kubernetes.io/name: hass

--- a/homebox/externalsecret.yaml
+++ b/homebox/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: homebox-postgres-secrets
+
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/homebox/kustomization.yaml
+++ b/homebox/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   # External secrets
+
 - externalsecret.yaml
 
   # HomeBox resources
@@ -21,6 +22,7 @@ resources:
 - helm/postgresql/primary/svc-headless.yaml
 
 patches:
+
 - target:
     kind: Deployment
     name: homebox
@@ -36,8 +38,10 @@ patches:
           secretKeyRef:
             name: homebox-postgresql
             key: postgres-password
+
 # Add labels for metrics
 labels:
+
 - pairs:
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox

--- a/homepage/kustomization.yaml
+++ b/homepage/kustomization.yaml
@@ -6,8 +6,10 @@ resources:
 - helm/templates/common.yaml
 
 labels:
+
 - pairs:
     app: homepage
+
 configMapGenerator:
 - name: homepage
   options:
@@ -22,6 +24,7 @@ configMapGenerator:
   - services.yaml
 
 patches:
+
 - target:
     kind: Deployment
     name: homepage

--- a/homepage/services.yaml
+++ b/homepage/services.yaml
@@ -7,6 +7,7 @@
   - Z-Wave JS:
       href: http://zwavejs.oneill.net:8091/
       icon: mdi-z-wave
+
 - Home Lab:
   - SpiderDuo KVM:
       href: https://spiderduo.oneill.net

--- a/homepage/values.yaml
+++ b/homepage/values.yaml
@@ -7,6 +7,7 @@ image:
 serviceAccount:
   create: true
   name: homepage
+
 # This enables the service account to access the necessary resources
 enableRbac: true
 

--- a/ingress-nginx/kustomization.yaml
+++ b/ingress-nginx/kustomization.yaml
@@ -19,5 +19,6 @@ resources:
 - helm/controller-serviceaccount.yaml
 
 labels:
+
 - pairs:
     app: ingress-nginx

--- a/ingress-nginx/namespace.yaml
+++ b/ingress-nginx/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: ingress-nginx

--- a/kube-state-metrics/kustomization.yaml
+++ b/kube-state-metrics/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - helm/templates/service.yaml
 
 labels:
+
 - pairs:
     app: kube-state-metrics
   includeSelectors: true

--- a/loki/helm/loki.dist.yaml
+++ b/loki/helm/loki.dist.yaml
@@ -1,1 +1,50 @@
-"auth_enabled: false\nchunk_store_config:\n  max_look_back_period: 0s\ncompactor:\n  retention_enabled: true\n  shared_store: filesystem\n  working_directory: /data/loki/boltdb-shipper-compactor\ningester:\n  chunk_block_size: 262144\n  chunk_idle_period: 3m\n  chunk_retain_period: 1m\n  lifecycler:\n    ring:\n      replication_factor: 1\n  max_transfer_retries: 0\n  wal:\n    dir: /data/loki/wal\nlimits_config:\n  enforce_metric_name: false\n  ingestion_rate_mb: 32\n  max_entries_limit_per_query: 5000\n  reject_old_samples: true\n  reject_old_samples_max_age: 168h\n  retention_period: 30d\nmemberlist:\n  join_members:\n  - 'loki-memberlist'\nschema_config:\n  configs:\n  - from: \"2020-10-24\"\n    index:\n      period: 24h\n      prefix: index_\n    object_store: filesystem\n    schema: v11\n    store: boltdb-shipper\nserver:\n  grpc_listen_port: 9095\n  http_listen_port: 3100\nstorage_config:\n  boltdb_shipper:\n    active_index_directory: /data/loki/boltdb-shipper-active\n    cache_location: /data/loki/boltdb-shipper-cache\n    cache_ttl: 24h\n    shared_store: filesystem\n  filesystem:\n    directory: /data/loki/chunks\ntable_manager:\n  retention_deletes_enabled: false\n  retention_period: 0s"
+auth_enabled: false
+chunk_store_config:
+  max_look_back_period: 0s
+compactor:
+  retention_enabled: true
+  shared_store: filesystem
+  working_directory: /data/loki/boltdb-shipper-compactor
+ingester:
+  chunk_block_size: 262144
+  chunk_idle_period: 3m
+  chunk_retain_period: 1m
+  lifecycler:
+    ring:
+      replication_factor: 1
+  max_transfer_retries: 0
+  wal:
+    dir: /data/loki/wal
+limits_config:
+  enforce_metric_name: false
+  ingestion_rate_mb: 32
+  max_entries_limit_per_query: 5000
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  retention_period: 30d
+memberlist:
+  join_members:
+  - 'loki-memberlist'
+schema_config:
+  configs:
+  - from: "2020-10-24"
+    index:
+      period: 24h
+      prefix: index_
+    object_store: filesystem
+    schema: v11
+    store: boltdb-shipper
+server:
+  grpc_listen_port: 9095
+  http_listen_port: 3100
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /data/loki/boltdb-shipper-active
+    cache_location: /data/loki/boltdb-shipper-cache
+    cache_ttl: 24h
+    shared_store: filesystem
+  filesystem:
+    directory: /data/loki/chunks
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s

--- a/loki/kustomization.yaml
+++ b/loki/kustomization.yaml
@@ -11,9 +11,11 @@ resources:
 - helm/loki/templates/service-memberlist.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
+
 secretGenerator:
 - name: loki
   files:
@@ -21,6 +23,7 @@ secretGenerator:
   type: Opaque
 
 patches:
+
 - target:
     kind: StatefulSet
     name: loki

--- a/loki/values.yaml
+++ b/loki/values.yaml
@@ -1,12 +1,14 @@
 ---
 persistence:
   enabled: true
+
 config:
   compactor:
     retention_enabled: true
   limits_config:
     retention_period: 30d
     ingestion_rate_mb: 32
+
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: http-metrics

--- a/meshcentral/deploy.yaml
+++ b/meshcentral/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: meshcentral
+
 spec:
   replicas: 1
   selector:

--- a/meshcentral/ingress.yaml
+++ b/meshcentral/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: meshcentral
   annotations:
@@ -10,6 +11,7 @@ metadata:
     gethomepage.dev/description: AMT/vPro management
     gethomepage.dev/group: Home Lab
     gethomepage.dev/icon: meshcentral.png
+
 spec:
   tls:
   - hosts:

--- a/meshcentral/kustomization.yaml
+++ b/meshcentral/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - pvc.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: meshcentral
     app.kubernetes.io/instance: meshcentral

--- a/meshcentral/pvc.yaml
+++ b/meshcentral/pvc.yaml
@@ -1,19 +1,24 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: meshcentral-data
+
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
       storage: 100Gi
+
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: meshcentral-files
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/meshcentral/service.yaml
+++ b/meshcentral/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: meshcentral
+
 spec:
   selector:
     app.kubernetes.io/name: meshcentral

--- a/metallb/config.yaml
+++ b/metallb/config.yaml
@@ -1,18 +1,23 @@
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
+
 metadata:
   name: default
   namespace: metallb-system
+
 spec:
   addresses:
   - 172.19.74.32/27
+
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
+
 metadata:
   name: static
   namespace: metallb-system
+
 spec:
   addresses:
   - 172.19.74.20/32
@@ -20,12 +25,15 @@ spec:
   - 172.19.74.22/32
   - 172.19.74.23/32
   autoAssign: false
+
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
+
 metadata:
   name: l2advertisement1
   namespace: metallb-system
+
 spec:
   # Control plane is hosted in a VM that is also on the same host as the
   # tailscale subnet router, so we want to exclude metallb from putting IPS on
@@ -37,12 +45,15 @@ spec:
       values: []
   ipAddressPools:
   - default
+
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
+
 metadata:
   name: l2advertisement2
   namespace: metallb-system
+
 spec:
   # See above
   nodeSelectors:

--- a/metallb/kustomization.yaml
+++ b/metallb/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
 - config.yaml
 
 labels:
+
 - pairs:
     app: metallb

--- a/metallb/namespace.yaml
+++ b/metallb/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: metallb-system

--- a/metrics-server/kustomization.yaml
+++ b/metrics-server/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
 - helm/serviceaccount.yaml
 
 labels:
+
 - pairs:
     app: metrics-server

--- a/mosquitto/deploy.yaml
+++ b/mosquitto/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: mosquitto
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   selector:
     matchLabels:

--- a/mosquitto/externalsecret.yaml
+++ b/mosquitto/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: mosquitto-users
+
 spec:
   secretStoreRef:
     name: production

--- a/mosquitto/kustomization.yaml
+++ b/mosquitto/kustomization.yaml
@@ -10,10 +10,12 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: mosquitto
     app.kubernetes.io/instance: mosquitto
   includeSelectors: true
+
 configMapGenerator:
 - name: mosquitto
   files:

--- a/mosquitto/pvc.yaml
+++ b/mosquitto/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: mosquitto-data
   labels:
     k8s-app: mosquitto-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/mosquitto/service.yaml
+++ b/mosquitto/service.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   labels:
     name: mosquitto
@@ -8,6 +9,7 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: mqtt.k.oneill.net
     metallb.io/allow-shared-ip: plexmediaserver
   name: mosquitto
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.21

--- a/mqtt-log/deploy.yaml
+++ b/mqtt-log/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: mqtt-log
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   selector:
     matchLabels:

--- a/mqtt-log/externalsecret.yaml
+++ b/mqtt-log/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: mqtt-log
+
 spec:
   secretStoreRef:
     name: production

--- a/mqtt-log/kustomization.yaml
+++ b/mqtt-log/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: mqtt-log
     app.kubernetes.io/instance: mqtt-log

--- a/n8n/externalsecret.yaml
+++ b/n8n/externalsecret.yaml
@@ -1,9 +1,11 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: n8n-secrets
   namespace: n8n
+
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -25,12 +27,15 @@ spec:
     remoteRef:
       key: n8n
       property: db_password
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: n8n-postgres-secrets
   namespace: n8n
+
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -44,12 +49,15 @@ spec:
     remoteRef:
       key: n8n
       property: db_password
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: n8n-valkey
   namespace: n8n
+
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/n8n/kustomization.yaml
+++ b/n8n/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
 - helm/valkey/templates/primary/serviceaccount.yaml
 
 patches:
+
 - target:
     kind: Ingress
     name: n8n

--- a/n8n/namespace.yaml
+++ b/n8n/namespace.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: n8n
   labels:

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -30,6 +30,7 @@ main:
     n8n:
       protocol: https
       host: n8n.k.oneill.net
+
 #      port: 443
       webhook_url: https://n8n.k.oneill.net/
       editor_base_url: https://n8n.k.oneill.net/

--- a/netatmo-exporter/deploy.yaml
+++ b/netatmo-exporter/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: netatmo-exporter
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/netatmo-exporter/externalsecret.yaml
+++ b/netatmo-exporter/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: netatmo-exporter
+
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/netatmo-exporter/ingress.yaml
+++ b/netatmo-exporter/ingress.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: netatmo-exporter
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+
 spec:
   ingressClassName: nginx
   tls:

--- a/netatmo-exporter/kustomization.yaml
+++ b/netatmo-exporter/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: netatmo-exporter
     app.kubernetes.io/instance: netatmo-exporter

--- a/netatmo-exporter/pvc.yaml
+++ b/netatmo-exporter/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: netatmo-exporter-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/netatmo-exporter/service.yaml
+++ b/netatmo-exporter/service.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   labels:
     name: netatmo-exporter
@@ -8,6 +9,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9210'
+
 spec:
   selector:
     app.kubernetes.io/name: netatmo-exporter

--- a/netatmo-wunderground-agent/deploy.yaml
+++ b/netatmo-wunderground-agent/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: netatmo-wunderground-agent
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/netatmo-wunderground-agent/externalsecret.yaml
+++ b/netatmo-wunderground-agent/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: netatmo-wunderground-agent
+
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/netatmo-wunderground-agent/kustomization.yaml
+++ b/netatmo-wunderground-agent/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: netatmo-wunderground-agent
     app.kubernetes.io/instance: netatmo-wunderground-agent

--- a/netatmo-wunderground-agent/pvc.yaml
+++ b/netatmo-wunderground-agent/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: netatmo-wunderground-agent-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/node-feature-discovery/kustomization.yaml
+++ b/node-feature-discovery/kustomization.yaml
@@ -19,5 +19,6 @@ resources:
 - helm/templates/worker.yaml
 
 labels:
+
 - pairs:
     app: node-feature-discovery

--- a/node-feature-discovery/namespace.yaml
+++ b/node-feature-discovery/namespace.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
 kind: Namespace
+
 metadata:
   name: node-feature-discovery

--- a/pihole/deploy.yaml
+++ b/pihole/deploy.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: pihole
   labels:
@@ -8,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: pihole
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/pihole/externalsecret.yaml
+++ b/pihole/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: pihole
+
 spec:
   secretStoreRef:
     name: production

--- a/pihole/ingress.yaml
+++ b/pihole/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: pihole
   annotations:
@@ -9,6 +10,7 @@ metadata:
     gethomepage.dev/name: Pi Hole
     gethomepage.dev/group: Home Lab
     gethomepage.dev/icon: pi-hole.png
+
 spec:
   tls:
   - hosts:

--- a/pihole/kustomization.yaml
+++ b/pihole/kustomization.yaml
@@ -13,10 +13,12 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: pihole
     app.kubernetes.io/instance: pihole
   includeSelectors: true
+
 images:
 - name: pihole/pihole
   newTag: 2025.07.1@sha256:f84c1654bfbafc44e2ac8447a1fa2fb739eae66395b4c179d2c59cb93e1321f3

--- a/pihole/pvc-config.yaml
+++ b/pihole/pvc-config.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: pihole-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/pihole/pvc-dnsmasq.yaml
+++ b/pihole/pvc-dnsmasq.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: pihole-dnsmasq
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/pihole/service-dns-tcp.yaml
+++ b/pihole/service-dns-tcp.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: pihole-dns-tcp
   annotations:
     metallb.io/allow-shared-ip: pihole
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.23

--- a/pihole/service-dns-udp.yaml
+++ b/pihole/service-dns-udp.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: pihole-dns-udp
   annotations:
     metallb.io/allow-shared-ip: pihole
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.23

--- a/pihole/service.yaml
+++ b/pihole/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: pihole
+
 spec:
   selector:
     app.kubernetes.io/name: pihole

--- a/plexmediaserver/deploy.yaml
+++ b/plexmediaserver/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: plexmediaserver
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   selector:

--- a/plexmediaserver/externalsecret.yaml
+++ b/plexmediaserver/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: plexmediaserver
+
 spec:
   secretStoreRef:
     name: production

--- a/plexmediaserver/ingress.yaml
+++ b/plexmediaserver/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: plexmediaserver
   annotations:
@@ -10,6 +11,7 @@ metadata:
     gethomepage.dev/description: Plex Media Server
     gethomepage.dev/group: Media
     gethomepage.dev/icon: plex.png
+
 spec:
   tls:
   - hosts:

--- a/plexmediaserver/kustomization.yaml
+++ b/plexmediaserver/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: plexmediaserver
     app.kubernetes.io/instance: plexmediaserver

--- a/plexmediaserver/pvc.yaml
+++ b/plexmediaserver/pvc.yaml
@@ -1,19 +1,24 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: plexmediaserver-config
+
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
+
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: plexmediaserver-transcode
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/plexmediaserver/service.yaml
+++ b/plexmediaserver/service.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: plexmediaserver
   labels:
@@ -8,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: plexmediaserver
   annotations:
     metallb.io/allow-shared-ip: plexmediaserver
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.21
@@ -18,9 +20,11 @@ spec:
   selector:
     app.kubernetes.io/name: plexmediaserver
     app.kubernetes.io/instance: plexmediaserver
+
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: plexmediaserver-udp
   labels:
@@ -28,6 +32,7 @@ metadata:
     app.kubernetes.io/instance: plexmediaserver
   annotations:
     metallb.io/allow-shared-ip: plexmediaserver
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.21

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -1,8 +1,10 @@
 ---
 global:
   scrape_interval: 15s
+
 rule_files:
 - /etc/prometheus/rules.yml
+
 alerting:
   alertmanagers:
 
@@ -10,6 +12,7 @@ alerting:
     static_configs:
     - targets:
       - alertmanager.k.oneill.net:443
+
 scrape_configs:
 - job_name: prometheus
 
@@ -18,6 +21,7 @@ scrape_configs:
 
   static_configs:
   - targets: [localhost:9090]
+
 - job_name: node resources
   static_configs:
   - targets:
@@ -106,6 +110,7 @@ scrape_configs:
     # Kubernetes apiserver.  This means it will work if Prometheus is running out of
     # cluster, or can't connect to nodes for some other reason (e.g. because of
     # firewalling).
+
 - job_name: kubernetes-nodes
 
   # Default to scraping over https. If required, just disable this or change to
@@ -134,6 +139,7 @@ scrape_configs:
     regex: (.+)
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics
+
 # Scrape config for Kubelet cAdvisor.
 #
 # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
@@ -176,6 +182,7 @@ scrape_configs:
     regex: (.+)
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
 # Scrape config for service endpoints.
 #
 # The relabeling allows the actual service scrape endpoint to be configured
@@ -220,6 +227,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_interval]
     action: replace
     target_label: scrape_interval
+
 # Example scrape config for probing services via the Blackbox Exporter.
 #
 # The relabeling allows the actual service scrape endpoint to be configured
@@ -251,6 +259,7 @@ scrape_configs:
     target_label: kubernetes_namespace
   - source_labels: [__meta_kubernetes_service_name]
     target_label: kubernetes_name
+
 # Example scrape config for pods
 #
 # The relabeling allows the actual pod scrape endpoint to be configured via the

--- a/prometheus/deploy.yaml
+++ b/prometheus/deploy.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: prometheus
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   replicas: 1
   strategy:

--- a/prometheus/externalsecret.yaml
+++ b/prometheus/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: prometheus
+
 spec:
   secretStoreRef:
     name: production

--- a/prometheus/ingress.yaml
+++ b/prometheus/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: prometheus
   annotations:
@@ -9,6 +10,7 @@ metadata:
     gethomepage.dev/name: Prometheus
     gethomepage.dev/group: Monitoring
     gethomepage.dev/icon: prometheus.png
+
 spec:
   tls:
   - hosts:

--- a/prometheus/kustomization.yaml
+++ b/prometheus/kustomization.yaml
@@ -12,10 +12,12 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: prometheus
   includeSelectors: true
+
 configMapGenerator:
 - name: prometheus
   files:

--- a/prometheus/pvc.yaml
+++ b/prometheus/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: prometheus-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/prometheus/rbac.yaml
+++ b/prometheus/rbac.yaml
@@ -1,13 +1,17 @@
 ---
 apiVersion: v1
 kind: ServiceAccount
+
 metadata:
   name: prometheus
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
+
 metadata:
   name: prometheus
+
 rules:
 - apiGroups: ['']
   resources:
@@ -23,12 +27,15 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
+
 metadata:
   name: prometheus
+
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: prometheus
+
 subjects:
 - kind: ServiceAccount
   name: prometheus

--- a/prometheus/service.yaml
+++ b/prometheus/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
   name: prometheus
+
 spec:
   selector:
     app.kubernetes.io/name: prometheus

--- a/promtail/externalsecret.yaml
+++ b/promtail/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: promtail
+
 spec:
   secretStoreRef:
     name: production

--- a/promtail/kustomization.yaml
+++ b/promtail/kustomization.yaml
@@ -11,8 +11,10 @@ resources:
 - helm/promtail/templates/serviceaccount.yaml
 
 labels:
+
 - pairs:
     app: promtail
+
 secretGenerator:
 - name: promtail
   files:

--- a/promtail/values.yaml
+++ b/promtail/values.yaml
@@ -4,6 +4,7 @@ config:
   snippets:
     pipelineStages:
     - docker: {}
+
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: http-metrics

--- a/prowlarr/deploy.yaml
+++ b/prowlarr/deploy.yaml
@@ -1,11 +1,13 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: prowlarr
   annotations:
     reloader.stakater.com/auto: 'true'
     secret.reloader.stakater.com/reload: iscsi-chap-secret
+
 spec:
   strategy:
     type: Recreate

--- a/prowlarr/ingress.yaml
+++ b/prowlarr/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: prowlarr
   annotations:
@@ -10,6 +11,7 @@ metadata:
     gethomepage.dev/description: Indexer Manager
     gethomepage.dev/group: Media Tools
     gethomepage.dev/icon: prowlarr.png
+
 spec:
   tls:
   - hosts:

--- a/prowlarr/kustomization.yaml
+++ b/prowlarr/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: prowlarr
     app.kubernetes.io/instance: prowlarr

--- a/prowlarr/service.yaml
+++ b/prowlarr/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: prowlarr
+
 spec:
   ports:
   - port: 9696

--- a/pushgateway/deploy.yaml
+++ b/pushgateway/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: pushgateway
+
 spec:
   replicas: 1
   selector:

--- a/pushgateway/ingress.yaml
+++ b/pushgateway/ingress.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: pushgateway
   labels:
     k8s-app: pushgateway
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+
 spec:
   tls:
   - hosts:

--- a/pushgateway/kustomization.yaml
+++ b/pushgateway/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: pushgateway
     app.kubernetes.io/instance: pushgateway

--- a/pushgateway/service.yaml
+++ b/pushgateway/service.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
     name: pushgateway
   name: pushgateway
+
 spec:
   selector:
     app.kubernetes.io/name: pushgateway

--- a/qbit_manage/deployment.yaml
+++ b/qbit_manage/deployment.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: qbit-manage
   labels:
     app: qbit-manage
+
 spec:
   replicas: 1
   selector:

--- a/qbit_manage/externalsecret.yaml
+++ b/qbit_manage/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: qbit-manage
+
 spec:
   secretStoreRef:
     name: production

--- a/qbit_manage/ingress.yaml
+++ b/qbit_manage/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: qbit-manage
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: qBit Manage
     gethomepage.dev/group: Downloaders
     gethomepage.dev/icon: qbittorrent.png
+
 spec:
   ingressClassName: nginx
   tls:

--- a/qbit_manage/kustomization.yaml
+++ b/qbit_manage/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - pvc.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: qbit-manage
     app.kubernetes.io/instance: qbit-manage

--- a/qbit_manage/pvc.yaml
+++ b/qbit_manage/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
+
 metadata:
   name: qbit-manage-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/qbit_manage/service.yaml
+++ b/qbit_manage/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: qbit-manage
   labels:
     app: qbit-manage
+
 spec:
   ports:
   - port: 8080

--- a/qbittorrent/deployment.yaml
+++ b/qbittorrent/deployment.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: qbittorrent
   labels:
     app: qbittorrent
+
 spec:
   strategy:
     type: Recreate

--- a/qbittorrent/ingress.yaml
+++ b/qbittorrent/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: qbittorrent
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: qBittorrent
     gethomepage.dev/group: Downloaders
     gethomepage.dev/icon: qbittorrent.png
+
 spec:
   tls:
   - hosts:

--- a/qbittorrent/kustomization.yaml
+++ b/qbittorrent/kustomization.yaml
@@ -15,6 +15,7 @@ images:
   newTag: 5.1.2@sha256:db088f4b2afec2fb1c7d61d800de37af1d098722ee3700829b25a8ccc88d8416
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: qbittorrent
     app.kubernetes.io/instance: qbittorrent

--- a/qbittorrent/pvc.yaml
+++ b/qbittorrent/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: qbittorrent-config
   labels:
     k8s-app: qbittorrent
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/qbittorrent/service.yaml
+++ b/qbittorrent/service.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: qbittorrent
   labels:
     app: qbittorrent
   annotations:
     metallb.io/allow-shared-ip: transmission
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.22
@@ -20,15 +22,18 @@ spec:
     protocol: TCP
   selector:
     app: qbittorrent
+
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: qbittorrent-udp
   labels:
     app: qbittorrent
   annotations:
     metallb.io/allow-shared-ip: transmission
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.22

--- a/radarr/deployment.yaml
+++ b/radarr/deployment.yaml
@@ -1,11 +1,13 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: radarr
   annotations:
     reloader.stakater.com/auto: 'true'
     secret.reloader.stakater.com/reload: iscsi-chap-secret
+
 spec:
   strategy:
     type: Recreate

--- a/radarr/ingress.yaml
+++ b/radarr/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: radarr
   annotations:
@@ -10,6 +11,7 @@ metadata:
     gethomepage.dev/description: Movie Manager
     gethomepage.dev/group: Media
     gethomepage.dev/icon: radarr.png
+
 spec:
   tls:
   - hosts:

--- a/radarr/kustomization.yaml
+++ b/radarr/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: radarr
     app.kubernetes.io/instance: radarr

--- a/radarr/pvc.yaml
+++ b/radarr/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: radarr-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/radarr/service.yaml
+++ b/radarr/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: radarr
+
 spec:
   ports:
   - port: 7878

--- a/reloader/kustomization.yaml
+++ b/reloader/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - helm/templates/deployment.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: reloader

--- a/resticprofile/cronjob-b2-forget.yaml
+++ b/resticprofile/cronjob-b2-forget.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: resticprofile-b2-forget
+
 spec:
   schedule: 0 2 * * *  # Daily at 2 AM (after backup completes)
   concurrencyPolicy: Forbid

--- a/resticprofile/cronjob-b2.yaml
+++ b/resticprofile/cronjob-b2.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: resticprofile-b2
+
 spec:
   schedule: 0 18 * * *  # Daily at 18:00 (6 PM)
   concurrencyPolicy: Forbid

--- a/resticprofile/cronjob-copy-main.yaml
+++ b/resticprofile/cronjob-copy-main.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: resticprofile-copy-main
+
 spec:
   schedule: 18 5 * * *
   concurrencyPolicy: Forbid

--- a/resticprofile/externalsecret.yaml
+++ b/resticprofile/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: resticprofile
+
 spec:
   secretStoreRef:
     name: production
@@ -11,11 +13,14 @@ spec:
   dataFrom:
   - extract:
       key: resticprofile
+
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: resticprofile-rclone
+
 spec:
   secretStoreRef:
     name: production

--- a/resticprofile/kustomization.yaml
+++ b/resticprofile/kustomization.yaml
@@ -10,16 +10,19 @@ resources:
 - externalsecret.yaml
 
 configMapGenerator:
+
 - files:
   - profiles.yaml
   name: resticprofile-config
   options:
     disableNameSuffixHash: true
+
 - files:
   - rclone.conf
   name: rclone-config
   options:
     disableNameSuffixHash: true
+
 images:
 - name: alpine
   newTag: 3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1

--- a/resticprofile/profiles.yaml
+++ b/resticprofile/profiles.yaml
@@ -58,6 +58,7 @@ b2:
   prometheus-push: https://pushgateway.k.oneill.net/
   check:
     read-data-subset: 1%
+
 # B2 copy profile (copy from local repo to B2)
 copy-main:
   compression: max

--- a/resticprofile/pvc.yaml
+++ b/resticprofile/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: resticprofile-cache
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/sabnzbd/deployment.yaml
+++ b/sabnzbd/deployment.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: sabnzbd
+
 spec:
   strategy:
     type: Recreate

--- a/sabnzbd/ingress.yaml
+++ b/sabnzbd/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: sabnzbd
   annotations:
@@ -9,6 +10,7 @@ metadata:
     gethomepage.dev/name: SABnzbd
     gethomepage.dev/group: Downloaders
     gethomepage.dev/icon: sabnzbd.png
+
 spec:
   tls:
   - hosts:

--- a/sabnzbd/kustomization.yaml
+++ b/sabnzbd/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: sabnzbd
     app.kubernetes.io/instance: sabnzbd

--- a/sabnzbd/pvc.yaml
+++ b/sabnzbd/pvc.yaml
@@ -1,8 +1,10 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: sabnzbd-config
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/sabnzbd/service.yaml
+++ b/sabnzbd/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: sabnzbd
+
 spec:
   ports:
   - port: 8080

--- a/smokeping/deployment.yaml
+++ b/smokeping/deployment.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: smokeping
+
 spec:
   strategy:
     type: Recreate

--- a/smokeping/ingress.yaml
+++ b/smokeping/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: smokeping
   annotations:
@@ -9,6 +10,7 @@ metadata:
     gethomepage.dev/name: Smokeping
     gethomepage.dev/group: Monitoring
     gethomepage.dev/icon: smokeping.png
+
 spec:
   tls:
   - hosts:

--- a/smokeping/kustomization.yaml
+++ b/smokeping/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: smokeping
     app.kubernetes.io/instance: smokeping

--- a/smokeping/pvc.yaml
+++ b/smokeping/pvc.yaml
@@ -1,19 +1,24 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: smokeping-config
+
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
+
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: smokeping-data
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/smokeping/service.yaml
+++ b/smokeping/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: smokeping
+
 spec:
   ports:
   - port: 80

--- a/sonarr/deployment.yaml
+++ b/sonarr/deployment.yaml
@@ -1,11 +1,13 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: sonarr
   annotations:
     reloader.stakater.com/auto: 'true'
     secret.reloader.stakater.com/reload: iscsi-chap-secret
+
 spec:
   strategy:
     type: Recreate

--- a/sonarr/ingress.yaml
+++ b/sonarr/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: sonarr
   labels:
@@ -12,6 +13,7 @@ metadata:
     gethomepage.dev/description: TV Manager
     gethomepage.dev/group: Media
     gethomepage.dev/icon: sonarr.png
+
 spec:
   tls:
   - hosts:

--- a/sonarr/kustomization.yaml
+++ b/sonarr/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ingress.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/instance: sonarr

--- a/sonarr/service.yaml
+++ b/sonarr/service.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: sonarr
   labels:
     app: sonarr
+
 spec:
   ports:
   - port: 8989

--- a/tautulli/deploy.yaml
+++ b/tautulli/deploy.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: tautulli
+
 spec:
   replicas: 1
   strategy:

--- a/tautulli/ingress.yaml
+++ b/tautulli/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: tautulli
   labels:
@@ -12,6 +13,7 @@ metadata:
     gethomepage.dev/description: Plex Monitoring and Statistics
     gethomepage.dev/group: Media
     gethomepage.dev/icon: tautulli.png
+
 spec:
   tls:
   - hosts:

--- a/tautulli/kustomization.yaml
+++ b/tautulli/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - service.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: tautulli
     app.kubernetes.io/instance: tautulli

--- a/tautulli/pvc.yaml
+++ b/tautulli/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: tautulli-config
   labels:
     k8s-app: tautulli
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/tautulli/service.yaml
+++ b/tautulli/service.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: tautulli
+
 spec:
   selector:
     app.kubernetes.io/name: tautulli

--- a/transmission/deployment.yaml
+++ b/transmission/deployment.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
+
 metadata:
   name: transmission
   annotations:
     reloader.stakater.com/auto: 'true'
+
 spec:
   strategy:
     type: Recreate

--- a/transmission/externalsecret.yaml
+++ b/transmission/externalsecret.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
+
 metadata:
   name: transmission
+
 spec:
   secretStoreRef:
     name: production

--- a/transmission/ingress.yaml
+++ b/transmission/ingress.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: transmission
   labels:
@@ -11,6 +12,7 @@ metadata:
     gethomepage.dev/name: Transmission
     gethomepage.dev/group: Downloaders
     gethomepage.dev/icon: transmission.png
+
 spec:
   tls:
   - hosts:

--- a/transmission/kustomization.yaml
+++ b/transmission/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - externalsecret.yaml
 
 labels:
+
 - pairs:
     app.kubernetes.io/name: transmission
     app.kubernetes.io/instance: transmission

--- a/transmission/pvc.yaml
+++ b/transmission/pvc.yaml
@@ -1,10 +1,12 @@
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
+
 metadata:
   name: transmission-config
   labels:
     k8s-app: transmission
+
 spec:
   accessModes:
   - ReadWriteOnce

--- a/transmission/service.yaml
+++ b/transmission/service.yaml
@@ -1,12 +1,14 @@
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: transmission
   labels:
     app: transmission
   annotations:
     metallb.io/allow-shared-ip: transmission
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.22
@@ -20,15 +22,18 @@ spec:
     protocol: TCP
   selector:
     app: transmission
+
 ---
 apiVersion: v1
 kind: Service
+
 metadata:
   name: transmission-udp
   labels:
     app: transmission
   annotations:
     metallb.io/allow-shared-ip: transmission
+
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.19.74.22

--- a/vpa/kustomization.yaml
+++ b/vpa/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
 - helm/templates/recommender-service-account.yaml
 
 labels:
+
 - pairs:
     app: vpa

--- a/vpa/values.yaml
+++ b/vpa/values.yaml
@@ -1,5 +1,6 @@
 ---
 updater:
   enabled: false
+
 admissionController:
   enabled: false

--- a/vrroom-daily-reboot/cronjob.yaml
+++ b/vrroom-daily-reboot/cronjob.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: batch/v1
 kind: CronJob
+
 metadata:
   name: vrroom-daily-reboot
+
 spec:
   schedule: 0 5 * * *  # 5:00 AM daily in local time
   timeZone: America/New_York


### PR DESCRIPTION
Clean up YAML formatting across all Kubernetes manifests using yamlfix to prepare for consistent pre-commit state. This affects 212 files with formatting standardization.